### PR TITLE
fix: ServiceTab UI not refreshing to "running" after clicking start

### DIFF
--- a/app/src/main/java/com/soreverse/mcp/ServiceTab.kt
+++ b/app/src/main/java/com/soreverse/mcp/ServiceTab.kt
@@ -167,6 +167,7 @@ internal fun ServiceTab(
         settings.useDefaultWorkDir = treeUri == null
         runCatching { McpForegroundService.start(context) }
             .onSuccess {
+                running = true
                 portStatus = if (t.zh) "正在启动服务…" else "Starting service…"
                 endpoints = filteredEndpoints(context, settings, settings.port)
             }


### PR DESCRIPTION
## Bug 描述

在 SOMCP 控制台点击「启动服务」按钮后，页面仍显示「已停止」且无任何刷新，直到切到其他页面再返回「控制」页，状态才延迟变为「运行中」。

## 原因分析

`startServerUnchecked()` 调用 `McpForegroundService.start(context)` 异步启动服务后，只更新了 `portStatus` 文本（"正在启动服务…"），但**没有更新局部状态变量 `running`**。

`PowerSurface` 组件依赖 `running` 来决定显示「已停止」还是「运行中」，而 `running` 仅在 `LaunchedEffect(Unit)` 的轮询循环中更新（间隔 1~10 秒）。因此用户点击启动后，UI 停留在「已停止」状态，直到轮询下一次检测到 `McpForegroundService.isRunning() == true` 才刷新。

## 修复

在 `startServerUnchecked()` 的 `onSuccess` 分支中立即设置 `running = true`，让 UI 即时响应启动操作，无需等待轮询周期。

## 改动文件

- `app/src/main/java/com/soreverse/mcp/ServiceTab.kt` — 在 `startServerUnchecked()` 的 `onSuccess` 中添加 `running = true`

## 测试建议

1. 打开 SOMCP 控制台
2. 点击「启动服务」按钮
3. 验证：页面立即显示「运行中」而非「已停止」
4. 点击「停止服务」，验证：页面立即显示「已停止」