### PR TITLE
feat: support multiple concurrent APK MCP bridges (MT + NP)

### DIFF
--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -1,7 +1,6 @@
 name: Test v3
 
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   checks:
@@ -66,5 +67,11 @@ jobs:
         run: gradle :app:lintDebug --stacktrace
       - name: Debug build
         run: gradle :app:assembleDebug --stacktrace
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: somcp-debug
+          path: app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 7
       - name: Unit tests (strict)
         run: gradle :app:testDebugUnitTest --stacktrace -Pkotlin.compiler.allWarningsAsErrors=true

--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   checks:
@@ -67,11 +66,5 @@ jobs:
         run: gradle :app:lintDebug --stacktrace
       - name: Debug build
         run: gradle :app:assembleDebug --stacktrace
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: somcp-debug
-          path: app/build/outputs/apk/debug/app-debug.apk
-          retention-days: 7
       - name: Unit tests (strict)
         run: gradle :app:testDebugUnitTest --stacktrace -Pkotlin.compiler.allWarningsAsErrors=true

--- a/app/src/main/java/com/soreverse/mcp/ServiceTab.kt
+++ b/app/src/main/java/com/soreverse/mcp/ServiceTab.kt
@@ -106,7 +106,7 @@ internal fun ServiceTab(
         apkConnected = withContext(Dispatchers.IO) {
             val bridge = activeBridge(context)
             when {
-                settings.apkMcpUrl.isNotBlank() -> bridge.probe().online
+                settings.apkMcpConfigs.isNotEmpty() -> bridge.probe().online
                 settings.apkMcpAutoProbe -> bridge.autoDiscover(ApkMcpBridge.DEFAULT_PORT).online
                 else -> false
             }
@@ -121,17 +121,17 @@ internal fun ServiceTab(
             val url = ts?.publicUrl?.takeIf { it.isNotBlank() && ts.state == CloudflareTunnelManager.State.RUNNING }
             if (url != quickPublicUrl) quickPublicUrl = url
             val liveBridge = activeServer(context)?.apkBridge
-            val bridgeState = liveBridge?.state()
-            apkToolNames = bridgeState?.tools?.map { it.name }.orEmpty()
-            if (bridgeState?.online == true) {
+            apkToolNames = liveBridge?.mergedTools()?.map { it.name }.orEmpty()
+            val anyOnline = liveBridge?.allPrefixes()?.isNotEmpty() == true
+            if (anyOnline) {
                 apkConnected = true
             } else if (settings.apkMcpAutoProbe) {
                 apkConnected = withContext(Dispatchers.IO) {
                     val bridge = activeBridge(context)
-                    val result = if (settings.apkMcpUrl.isNotBlank()) bridge.probe() else bridge.autoDiscover(ApkMcpBridge.DEFAULT_PORT)
+                    val result = if (settings.apkMcpConfigs.isNotEmpty()) bridge.probe() else bridge.autoDiscover(ApkMcpBridge.DEFAULT_PORT)
                     result.online
                 }
-            } else if (liveBridge != null || settings.apkMcpUrl.isBlank()) {
+            } else if (liveBridge != null || settings.apkMcpConfigs.isEmpty()) {
                 apkConnected = false
             }
             keepAliveReady = isKeepAliveReady(context, settings)

--- a/app/src/main/java/com/soreverse/mcp/SettingsApkBridgePage.kt
+++ b/app/src/main/java/com/soreverse/mcp/SettingsApkBridgePage.kt
@@ -1,104 +1,295 @@
 package com.soreverse.mcp
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.soreverse.mcp.core.ApkMcpBridge
 import com.soreverse.mcp.core.SettingsStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
 
 @Composable
 internal fun SettingsApkBridgePage(t: UiText, settings: SettingsStore) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    var apkUrl by remember { mutableStateOf(settings.apkMcpUrl) }
-    var apkToken by remember { mutableStateOf(settings.apkMcpToken) }
+    var configs by remember { mutableStateOf(settings.apkMcpConfigs) }
     var apkAutoProbe by remember { mutableStateOf(settings.apkMcpAutoProbe) }
     var apkMerge by remember { mutableStateOf(settings.apkMcpMergeTools) }
-    var probeState by remember { mutableStateOf<ApkMcpBridge.State?>(null) }
-    PageScroll {
-        GlassGroup {
-            OutlinedTextField(
-                value = apkUrl,
-                onValueChange = { apkUrl = it; settings.apkMcpUrl = it },
-                label = { Text(if (t.zh) "APK MCP /mcp URL" else "APK MCP /mcp URL") },
-                singleLine = true,
-                shape = RoundedCornerShape(12.dp),
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = MaterialTheme.colorScheme.primary,
-                    unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f),
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
-                ),
-                modifier = Modifier.fillMaxWidth().padding(14.dp),
-            )
-            Text(
-                if (t.zh) "例如 MT 管理器侧边栏 APK MCP：http://192.168.x.x:8787/mcp；NP 管理器：http://192.168.x.x:8788/mcp" else "e.g. MT Manager APK MCP: http://192.168.x.x:8787/mcp, NP Manager: http://192.168.x.x:8788/mcp",
-                modifier = Modifier.padding(horizontal = 14.dp),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            GroupDivider()
-            OutlinedTextField(
-                value = apkToken,
-                onValueChange = { apkToken = it; settings.apkMcpToken = it },
-                label = { Text(if (t.zh) "Bearer token（可选）" else "Bearer token (optional)") },
-                singleLine = true,
-                shape = RoundedCornerShape(12.dp),
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = MaterialTheme.colorScheme.primary,
-                    unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f),
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
-                ),
-                modifier = Modifier.fillMaxWidth().padding(14.dp),
-            )
+    var showAddForm by remember { mutableStateOf(false) }
+    var newUrl by remember { mutableStateOf("") }
+    var newToken by remember { mutableStateOf("") }
+    var snapshot by remember { mutableStateOf<JSONObject?>(null) }
+
+    val bridge = activeBridge(context.applicationContext)
+
+    fun refreshSnapshot() {
+        scope.launch {
+            snapshot = withContext(Dispatchers.IO) {
+                bridge.probe()
+                bridge.snapshotJson()
+            }
         }
-        GlassGroup {
+    }
+
+    fun bridgeState(url: String): JSONObject? {
+        val bridges = snapshot?.optJSONArray("bridges") ?: return null
+        for (i in 0 until bridges.length()) {
+            val b = bridges.optJSONObject(i) ?: continue
+            if (b.optString("url") == url) return b
+        }
+        return null
+    }
+
+    PageScroll {
+        // ---- Bridge list ----
+        GlassGroup(title = if (t.zh) "桥接列表" else "Bridge List") {
+            if (configs.isEmpty()) {
+                Text(
+                    if (t.zh) "尚未添加任何桥接" else "No bridges configured",
+                    modifier = Modifier.padding(14.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            configs.forEachIndexed { index, config ->
+                if (index > 0) GroupDivider()
+                val st = bridgeState(config.url)
+                val online = st?.optBoolean("online") == true
+                val toolCount = st?.optInt("toolCount") ?: 0
+                val lastError = st?.optString("lastError") ?: ""
+                val latencyMs = st?.optLong("lastLatencyMs") ?: 0L
+
+                Row(
+                    Modifier.fillMaxWidth().padding(start = 14.dp, end = 4.dp, top = 8.dp, bottom = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    // Status dot
+                    Box(
+                        Modifier.size(10.dp).clip(CircleShape).background(
+                            if (online) AppleColors.systemGreen
+                            else if (st != null) AppleColors.systemRed
+                            else Color.Gray
+                        )
+                    )
+                    Spacer(Modifier.width(10.dp))
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            config.url,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            if (config.token.isNotBlank()) {
+                                Text(
+                                    "token: ${"\u2022".repeat(config.token.length.coerceIn(4, 12))}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Spacer(Modifier.width(8.dp))
+                            }
+                            if (online) {
+                                Text(
+                                    "$toolCount tools",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = AppleColors.systemGreen,
+                                )
+                                if (latencyMs > 0) {
+                                    Text(
+                                        "  ${latencyMs}ms",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            } else if (st != null && lastError.isNotBlank()) {
+                                Text(
+                                    lastError,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = AppleColors.systemRed,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            } else if (st != null) {
+                                Text(
+                                    if (t.zh) "离线" else "offline",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = AppleColors.systemRed,
+                                )
+                            }
+                        }
+                    }
+                    // Delete button
+                    IconButton(onClick = {
+                        bridge.removeBridge(config.url)
+                        configs = settings.apkMcpConfigs
+                        snapshot = null
+                    }) {
+                        Icon(Icons.Default.Close, if (t.zh) "移除" else "Remove", tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+            }
+
+            // ---- Add bridge form ----
+            GroupDivider()
+            if (showAddForm) {
+                OutlinedTextField(
+                    value = newUrl,
+                    onValueChange = { newUrl = it },
+                    label = { Text(if (t.zh) "APK MCP /mcp URL" else "APK MCP /mcp URL") },
+                    placeholder = { Text("http://192.168.x.x:8787/mcp") },
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f),
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
+                    ),
+                    modifier = Modifier.fillMaxWidth().padding(start = 14.dp, end = 14.dp, top = 8.dp),
+                )
+                OutlinedTextField(
+                    value = newToken,
+                    onValueChange = { newToken = it },
+                    label = { Text(if (t.zh) "Bearer token（可选）" else "Bearer token (optional)") },
+                    singleLine = true,
+                    shape = RoundedCornerShape(12.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f),
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
+                    ),
+                    modifier = Modifier.fillMaxWidth().padding(start = 14.dp, end = 14.dp, top = 8.dp),
+                )
+                Row(
+                    Modifier.fillMaxWidth().padding(14.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    SecondaryActionButton(
+                        if (t.zh) "取消" else "Cancel",
+                        { showAddForm = false; newUrl = ""; newToken = "" },
+                        modifier = Modifier.weight(1f),
+                    )
+                    PrimaryActionButton(
+                        if (t.zh) "添加并探测" else "Add & Probe",
+                        {
+                            val url = newUrl.trim()
+                            if (url.isNotBlank()) {
+                                scope.launch {
+                                    withContext(Dispatchers.IO) { bridge.probeUrl(url, newToken) }
+                                    configs = settings.apkMcpConfigs
+                                    refreshSnapshot()
+                                    showAddForm = false
+                                    newUrl = ""
+                                    newToken = ""
+                                }
+                            }
+                        },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            } else {
+                Row(Modifier.padding(horizontal = 14.dp, vertical = 4.dp)) {
+                    TextButton(onClick = { showAddForm = true }) {
+                        Icon(Icons.Default.Add, null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(4.dp))
+                        Text(if (t.zh) "添加桥接" else "Add Bridge")
+                    }
+                }
+                Text(
+                    if (t.zh) "支持同时连接多个 APK MCP 桥接（如 MT 管理器 + NP 管理器）" else "Supports multiple concurrent APK MCP bridges (e.g. MT Manager + NP Manager)",
+                    modifier = Modifier.padding(start = 14.dp, end = 14.dp, bottom = 8.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        // ---- Options ----
+        GlassGroup(title = if (t.zh) "选项" else "Options") {
             ToggleRow(if (t.zh) "持续自动探测" else "Continuous auto-probe", apkAutoProbe) { apkAutoProbe = it; settings.apkMcpAutoProbe = it }
             GroupDivider()
             ToggleRow(if (t.zh) "合并工具到 tools/list" else "Merge tools into tools/list", apkMerge) { apkMerge = it; settings.apkMcpMergeTools = it }
         }
+
+        // ---- Actions ----
         GlassGroup {
             Row(Modifier.padding(14.dp)) {
                 PrimaryActionButton(
-                    if (t.zh) "立即探测" else "Probe now",
-                    {
-                        scope.launch {
-                            val bridge = activeBridge(context.applicationContext)
-                            probeState = withContext(Dispatchers.IO) { bridge.probe() }
-                        }
-                    },
+                    if (t.zh) "探测全部" else "Probe All",
+                    { refreshSnapshot() },
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
-            probeState?.let {
-                val color = if (it.online) AppleColors.systemGreen else AppleColors.systemRed
+            snapshot?.let { snap ->
+                val bridges = snap.optJSONArray("bridges") ?: JSONArray()
+                val onlineCount = snap.optInt("onlineCount")
+                val text = if (t.zh) "状态：$onlineCount/${bridges.length()} 个桥接在线" else "State: $onlineCount/${bridges.length()} bridge(s) online"
                 Text(
-                    "${if (t.zh) "状态" else "State"}: ${if (it.online) (if (t.zh) "在线" else "online") else (if (t.zh) "离线" else "offline")}   ${if (t.zh) "工具数" else "tools"}: ${it.tools.size}",
-                    color = color,
+                    text,
+                    color = if (onlineCount > 0) AppleColors.systemGreen else AppleColors.systemRed,
                     style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 4.dp),
                 )
-                if (it.lastError.isNotBlank()) {
-                    Text(it.lastError, style = MaterialTheme.typography.bodySmall, color = color, modifier = Modifier.padding(horizontal = 14.dp, vertical = 4.dp))
+                // Show per-bridge status in probe results
+                if (bridges.length() > 0) {
+                    for (i in 0 until bridges.length()) {
+                        val b = bridges.optJSONObject(i) ?: continue
+                        val url = b.optString("url")
+                        val online = b.optBoolean("online")
+                        val tools = b.optInt("toolCount")
+                        val prefix = b.optString("toolPrefix")
+                        val label = ApkMcpBridge.prefixLabel(prefix)
+                        val line = if (online) {
+                            if (t.zh) "  \u2022 $label ($url) 在线 - $tools 工具" else "  \u2022 $label ($url) online - $tools tools"
+                        } else {
+                            if (t.zh) "  \u2022 $url 离线" else "  \u2022 $url offline"
+                        }
+                        Text(
+                            line,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (online) AppleColors.systemGreen else AppleColors.systemRed,
+                            modifier = Modifier.padding(horizontal = 14.dp),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                 }
             }
             Text(

--- a/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
@@ -7,21 +7,22 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
- * Bridge to an external "APK MCP" server (MT Manager or NP Manager).
+ * Bridge to multiple external "APK MCP" servers (MT Manager, NP Manager, etc.).
  *
- * Acts as an MCP gateway: discovers the remote server's tools via tools/list,
+ * Acts as an MCP gateway: discovers each remote server's tools via tools/list,
  * merges them under their native prefix (mt_apk_* or np_*) into our own
  * tools/list responses, and transparently forwards tools/call invocations
- * back to the remote server.
+ * back to the correct remote server based on the tool name prefix.
  *
- * When the remote is unreachable, tools are hidden so the local server behaves
- * as a standalone SO-only MCP. When reachable, the client gets a combined
- * SO+APK reverse-engineering toolset ("combo") without re-implementing APK
- * analysis from scratch.
+ * When all remotes are unreachable, tools are hidden so the local server behaves
+ * as a standalone SO-only MCP. When any remote is reachable, the client gets a
+ * combined SO+APK reverse-engineering toolset ("combo") without re-implementing
+ * APK analysis from scratch.
  */
 class ApkMcpBridge(private val settings: SettingsStore) {
 
@@ -50,274 +51,484 @@ class ApkMcpBridge(private val settings: SettingsStore) {
         fun lossRate(): Double = if (probes == 0L) 0.0 else probeFailures.toDouble() / probes
     }
 
-    private val _state = AtomicReference(State())
-    fun state(): State = _state.get()
+    /**
+     * Internal representation of a single bridge connection.
+     */
+    private class BridgeConnection(val url: String, val token: String) {
+        @Volatile var state: State = State(url = url)
+        private val client: OkHttpClient by lazy {
+            OkHttpClient.Builder()
+                .connectTimeout(8, TimeUnit.SECONDS)
+                .readTimeout(20, TimeUnit.SECONDS)
+                .build()
+        }
 
-    private val client: OkHttpClient by lazy {
-        OkHttpClient.Builder()
-            .connectTimeout(8, TimeUnit.SECONDS)
-            .readTimeout(20, TimeUnit.SECONDS)
-            .build()
+        @Volatile private var healthThread: Thread? = null
+        @Volatile private var healthStop = false
+
+        @Synchronized
+        fun probe(timeoutMs: Int = 8000): State {
+            try {
+                val req = buildJsonRpc(url, "tools/list", JSONObject(), id = connIdCounter.incrementAndGet())
+                val start = System.nanoTime()
+                val resp = post(req)
+                val latencyMs = (System.nanoTime() - start) / 1_000_000
+                val parsed = parseTools(resp)
+                val prefix = detectPrefix(parsed)
+                val prev = state
+                val s = State(
+                    url = url,
+                    online = true,
+                    lastError = "",
+                    tools = parsed,
+                    toolPrefix = prefix ?: prev.toolPrefix,
+                    lastCheckedAt = System.currentTimeMillis(),
+                    lastLatencyMs = latencyMs,
+                    probes = prev.probes + 1,
+                    probeFailures = prev.probeFailures,
+                    totalLatencyMs = prev.totalLatencyMs + latencyMs,
+                    maxLatencyMs = maxOf(prev.maxLatencyMs, latencyMs),
+                )
+                state = s
+                val label = prefixLabel(prefix)
+                AppLog.i("apk-mcp bridge online: ${parsed.size} tools from $url ($label, ${latencyMs}ms)")
+                return s
+            } catch (e: Exception) {
+                val prev = state
+                val s = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName,
+                    probes = prev.probes + 1, probeFailures = prev.probeFailures + 1,
+                    totalLatencyMs = prev.totalLatencyMs, maxLatencyMs = prev.maxLatencyMs)
+                state = s
+                AppLog.w("apk-mcp probe failed: $url ${e.message}")
+                return s
+            }
+        }
+
+        @Synchronized
+        fun ping(): State {
+            return try {
+                val req = buildJsonRpc(url, "initialize", JSONObject().put("client", "somcp-ping"), id = connIdCounter.incrementAndGet())
+                val start = System.nanoTime()
+                post(req)
+                val latencyMs = (System.nanoTime() - start) / 1_000_000
+                val prev = state
+                val s = if (!prev.online) {
+                    prev.copy(lastLatencyMs = latencyMs, lastCheckedAt = System.currentTimeMillis(),
+                        probes = prev.probes + 1, lastError = "", online = false, tools = prev.tools)
+                } else {
+                    State(url = url, online = true, lastError = "", tools = prev.tools,
+                        lastCheckedAt = System.currentTimeMillis(), lastLatencyMs = latencyMs,
+                        probes = prev.probes + 1, probeFailures = prev.probeFailures,
+                        totalLatencyMs = prev.totalLatencyMs + latencyMs, maxLatencyMs = maxOf(prev.maxLatencyMs, latencyMs))
+                }
+                state = s
+                s
+            } catch (e: Exception) {
+                val prev = state
+                val s = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName,
+                    probes = prev.probes + 1, probeFailures = prev.probeFailures + 1,
+                    totalLatencyMs = prev.totalLatencyMs, maxLatencyMs = prev.maxLatencyMs)
+                state = s
+                s
+            }
+        }
+
+        fun callTool(name: String, arguments: JSONObject): JSONObject {
+            val st = state
+            if (!st.online || st.url.isBlank()) {
+                return errorResult(name, "APK MCP $url is offline or not configured")
+            }
+            val params = JSONObject().put("name", name).put("arguments", arguments)
+            return try {
+                val req = buildJsonRpc(url, "tools/call", params, id = connIdCounter.incrementAndGet())
+                val resp = post(req)
+                parseToolResult(resp)
+            } catch (e: Exception) {
+                errorResult(name, "forward failed: ${e.message}")
+            }
+        }
+
+        fun startHealthMonitor(intervalMs: Long = 30_000) {
+            stopHealthMonitor()
+            healthStop = false
+            healthThread = Thread({
+                while (!healthStop && !Thread.currentThread().isInterrupted) {
+                    try {
+                        Thread.sleep(intervalMs)
+                    } catch (_: InterruptedException) { break }
+                    if (healthStop) break
+                    try {
+                        val req = buildJsonRpc(url, "tools/list", JSONObject(), id = connIdCounter.incrementAndGet())
+                        val resp = post(req)
+                        val parsed = parseTools(resp)
+                        val prefix = detectPrefix(parsed)
+                        if (prefix != null) {
+                            val cur = state
+                            state = State(url = url, online = true, lastError = "", tools = parsed, toolPrefix = prefix, lastCheckedAt = System.currentTimeMillis())
+                            if (!cur.online) AppLog.i("apk-mcp health: $url back online (${parsed.size} tools, prefix=$prefix)")
+                        }
+                    } catch (e: Exception) {
+                        val cur = state
+                        if (cur.online) {
+                            state = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName, tools = emptyList(), lastCheckedAt = System.currentTimeMillis())
+                            AppLog.w("apk-mcp health: $url marked offline (${e.message})")
+                        }
+                    }
+                }
+            }, "apk-mcp-health-$url").apply { isDaemon = true; start() }
+        }
+
+        fun stopHealthMonitor() {
+            healthStop = true
+            healthThread?.interrupt()
+            healthThread = null
+        }
+
+        private fun buildJsonRpc(url: String, method: String, params: JSONObject, id: Int): Request {
+            val body = JSONObject()
+                .put("jsonrpc", "2.0")
+                .put("id", id)
+                .put("method", method)
+                .put("params", params)
+                .toString()
+            val builder = Request.Builder().url(url).post(body.toRequestBody("application/json".toMediaType()))
+            if (token.isNotBlank()) builder.safeHeader("Authorization", "Bearer $token")
+            return builder.build()
+        }
+
+        private fun post(req: Request): String {
+            client.newCall(req).execute().use { r ->
+                val body = r.body?.string().orEmpty()
+                if (!r.isSuccessful) throw IllegalStateException("HTTP ${r.code}")
+                return body
+            }
+        }
+
+        private fun parseTools(body: String): List<ToolDef> {
+            val root = JSONObject(body)
+            val result = root.opt("result") as? JSONObject ?: return emptyList()
+            val tools = result.optJSONArray("tools") ?: return emptyList()
+            val out = ArrayList<ToolDef>(tools.length())
+            for (i in 0 until tools.length()) {
+                val t = tools.getJSONObject(i)
+                out.add(
+                    ToolDef(
+                        name = t.optString("name"),
+                        title = t.optString("title").takeIf { it.isNotBlank() },
+                        description = t.optString("description").takeIf { it.isNotBlank() },
+                        inputSchema = t.optJSONObject("inputSchema"),
+                        outputSchema = t.optJSONObject("outputSchema"),
+                    )
+                )
+            }
+            return out
+        }
+
+        private fun parseToolResult(body: String): JSONObject {
+            val root = JSONObject(body)
+            val result = root.opt("result")
+            return (result as? JSONObject) ?: JSONObject().put("raw", body)
+        }
+
+        private fun errorResult(name: String, msg: String): JSONObject {
+            return JSONObject().put("content", JSONArray().put(JSONObject().put("type", "text").put("text", "APK MCP error [$name]: $msg")))
+                .put("isError", true)
+                .put("source", "apk-mcp-bridge")
+        }
+
+        private fun detectPrefix(tools: List<ToolDef>): String? {
+            tools.firstOrNull { it.name.startsWith(MT_PREFIX) }?.let { return MT_PREFIX }
+            tools.firstOrNull { it.name.startsWith(NP_PREFIX) }?.let { return NP_PREFIX }
+            return null
+        }
+
+        private fun prefixLabel(prefix: String?): String = when (prefix) {
+            MT_PREFIX -> "MT Manager"
+            NP_PREFIX -> "NP Manager"
+            else -> "Unknown"
+        }
     }
 
-    fun configured(): Boolean = settings.apkMcpUrl.isNotBlank()
+    private val connections = CopyOnWriteArrayList<BridgeConnection>()
 
+    init {
+        syncConnectionsFromSettings()
+    }
+
+    /**
+     * Return a merged State representing the first online bridge,
+     * or the first configured bridge if none are online.
+     * This is used for backward compatibility with caller code that
+     * expects a single-bridge view.
+     */
+    fun state(): State {
+        val firstOnline = connections.firstOrNull { it.state.online }
+        if (firstOnline != null) return firstOnline.state
+        val first = connections.firstOrNull()
+        if (first != null) return first.state
+        return State()
+    }
+
+    /** Sync the internal connection list from settings. */
+    private fun syncConnectionsFromSettings() {
+        val configs = settings.apkMcpConfigs
+        // Remove connections whose URLs are no longer in config
+        val activeUrls = configs.map { it.url }.toSet()
+        connections.removeAll { it.url !in activeUrls }
+        // Add new connections
+        val existingUrls = connections.map { it.url }.toSet()
+        for (config in configs) {
+            if (config.url !in existingUrls) {
+                connections.add(BridgeConnection(config.url, config.token))
+            }
+        }
+    }
+
+    /** Ensure a connection exists for the given URL, adding it if new. */
+    private fun ensureConnection(url: String, token: String = ""): BridgeConnection {
+        syncConnectionsFromSettings()
+        return connections.firstOrNull { it.url == url } ?: run {
+            val conn = BridgeConnection(url, token)
+            connections.add(conn)
+            conn
+        }
+    }
+
+    fun configured(): Boolean = settings.apkMcpConfigs.isNotEmpty() || settings.apkMcpUrl.isNotBlank()
+
+    /**
+     * Auto-discover APK MCP servers on the standard ports.
+     * Returns the state of the first discovered server (for backward compatibility),
+     * but adds all discovered servers to the connection list.
+     */
     @Synchronized
     fun autoDiscover(port: Int = DEFAULT_PORT): State {
-        val allPorts = if (port == DEFAULT_PORT) listOf(port, NP_PORT) else listOf(port)
+        syncConnectionsFromSettings()
+        val allPorts = listOf(port, NP_PORT).distinct()
+        var firstState: State? = null
         for (p in allPorts) {
+            if (connections.any { it.url.contains(":$p/") }) continue
             val candidates = listOf(
                 "http://127.0.0.1:$p/mcp",
                 "http://localhost:$p/mcp",
             )
             for (url in candidates) {
                 try {
-                    val req = buildJsonRpc(url, "tools/list", JSONObject(), id = 1)
-                    val resp = post(req)
-                    val parsed = parseTools(resp)
-                    val prefix = parsed.firstOrNull { it.name.startsWith(MT_PREFIX) }?.let { MT_PREFIX }
-                        ?: parsed.firstOrNull { it.name.startsWith(NP_PREFIX) }?.let { NP_PREFIX }
-                        ?: continue
-                    settings.apkMcpUrl = url
-                    val s = State(url = url, online = true, lastError = "", tools = parsed, toolPrefix = prefix, lastCheckedAt = System.currentTimeMillis())
-                    _state.set(s)
-                    val label = if (prefix == MT_PREFIX) "MT Manager" else "NP Manager"
-                    AppLog.i("apk-mcp auto-discovered $label at $url (${parsed.size} tools, prefix=$prefix)")
-                    return s
-                } catch (_: Exception) {
-                }
+                    val conn = BridgeConnection(url, "")
+                    val st = conn.probe()
+                    if (st.online) {
+                        connections.add(conn)
+                        // Save to settings
+                        val configs = settings.apkMcpConfigs.toMutableList()
+                        if (configs.none { it.url == url }) {
+                            configs.add(SettingsStore.BridgeConfig(url, ""))
+                            settings.apkMcpConfigs = configs
+                        }
+                        if (firstState == null) firstState = st
+                        AppLog.i("apk-mcp auto-discovered ${prefixLabel(st.toolPrefix)} at $url (${st.tools.size} tools)")
+                        break
+                    }
+                } catch (_: Exception) {}
             }
         }
-        AppLog.i("apk-mcp auto-discovery: no APK MCP found on ports $allPorts")
-        return _state.get()
+        if (firstState == null) {
+            AppLog.i("apk-mcp auto-discovery: no APK MCP found on ports $allPorts")
+        }
+        return firstState ?: State()
     }
 
+    /** Probe all configured bridge connections in parallel. Returns the state of the first connection (backward compat). */
     @Synchronized
     fun probe(): State {
-        val url = settings.apkMcpUrl
-        if (url.isBlank()) {
-            val s = State(url = "", online = false, lastError = "not configured")
-            _state.set(s)
-            return s
-        }
+        syncConnectionsFromSettings()
+        if (connections.isEmpty()) return State()
+        // Probe all bridges concurrently so multi-bridge users see both
+        // bridges come up at the same time, not one-after-another.
+        val exec = java.util.concurrent.Executors.newFixedThreadPool(
+            connections.size.coerceIn(1, 4)
+        )
         try {
-            val req = buildJsonRpc(url, "tools/list", JSONObject(), id = 1)
-            val start = System.nanoTime()
-            val resp = post(req)
-            val latencyMs = (System.nanoTime() - start) / 1_000_000
-            val parsed = parseTools(resp)
-            val prefix = parsed.firstOrNull { it.name.startsWith(MT_PREFIX) }?.let { MT_PREFIX }
-                ?: parsed.firstOrNull { it.name.startsWith(NP_PREFIX) }?.let { NP_PREFIX }
-                ?: _state.get().toolPrefix
-            val prev = _state.get()
-            val s = State(
-                url = url,
-                online = true,
-                lastError = "",
-                tools = parsed,
-                toolPrefix = prefix,
-                lastCheckedAt = System.currentTimeMillis(),
-                lastLatencyMs = latencyMs,
-                probes = prev.probes + 1,
-                probeFailures = prev.probeFailures,
-                totalLatencyMs = prev.totalLatencyMs + latencyMs,
-                maxLatencyMs = maxOf(prev.maxLatencyMs, latencyMs),
-            )
-            _state.set(s)
-            val label = if (prefix == MT_PREFIX) "MT Manager" else "NP Manager"
-            AppLog.i("apk-mcp bridge online: ${parsed.size} tools from $url ($label, ${latencyMs}ms)")
-            return s
-        } catch (e: Exception) {
-            val prev = _state.get()
-            val s = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName, probes = prev.probes + 1, probeFailures = prev.probeFailures + 1, totalLatencyMs = prev.totalLatencyMs, maxLatencyMs = prev.maxLatencyMs)
-            _state.set(s)
-            AppLog.w("apk-mcp probe failed: ${e.message}")
-            return s
+            val snapshot = connections.map { conn -> conn.state }
+            val results = connections.map { conn ->
+                exec.submit<State> { conn.probe() }
+            }
+            results.forEach { it.get() }
+            return snapshot.firstOrNull() ?: State()
+        } finally {
+            exec.shutdown()
         }
     }
 
     /**
-     * Lightweight liveness probe (initialize round-trip). Cheaper than probe()
-     * since it parses the JSON-RPC envelope only and skips tool-schema
-     * decoding. Updates latency/failure counters but does NOT rewrite the
-     * tool list — call probe() after connectivity is (re)established to also
-     * refresh tools.
+     * Probe a specific URL (used when user adds a new bridge URL from UI).
+     * Adds the connection if successful.
      */
     @Synchronized
-    fun ping(): State {
-        val url = settings.apkMcpUrl
-        if (url.isBlank()) {
-            return _state.get()
-        }
-        return try {
-            val req = buildJsonRpc(url, "initialize", JSONObject().put("client", "somcp-ping"), id = nextId())
-            val start = System.nanoTime()
-            post(req)
-            val latencyMs = (System.nanoTime() - start) / 1_000_000
-            val prev = _state.get()
-            val s = if (!prev.online) {
-                prev.copy(lastLatencyMs = latencyMs, lastCheckedAt = System.currentTimeMillis(), probes = prev.probes + 1, lastError = "", online = false, tools = prev.tools)
-            } else {
-                State(url = url, online = true, lastError = "", tools = prev.tools, lastCheckedAt = System.currentTimeMillis(), lastLatencyMs = latencyMs, probes = prev.probes + 1, probeFailures = prev.probeFailures, totalLatencyMs = prev.totalLatencyMs + latencyMs, maxLatencyMs = maxOf(prev.maxLatencyMs, latencyMs))
+    fun probeUrl(url: String, token: String = ""): State {
+        val conn = ensureConnection(url, token)
+        val st = conn.probe()
+        // Save to settings if online
+        if (st.online) {
+            val configs = settings.apkMcpConfigs.toMutableList()
+            if (configs.none { it.url == url }) {
+                configs.add(SettingsStore.BridgeConfig(url, token))
+                settings.apkMcpConfigs = configs
             }
-            _state.set(s)
-            s
-        } catch (e: Exception) {
-            val prev = _state.get()
-            val s = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName, probes = prev.probes + 1, probeFailures = prev.probeFailures + 1, totalLatencyMs = prev.totalLatencyMs, maxLatencyMs = prev.maxLatencyMs)
-            _state.set(s)
-            s
         }
+        return st
     }
 
-    fun mergedTools(): List<ToolDef> {
-        val st = _state.get()
-        val prefix = st.toolPrefix
-        return if (st.online) st.tools.filter { it.name.startsWith(prefix) } else emptyList()
-    }
-
-    fun isBridgedTool(name: String): Boolean {
-        val prefix = _state.get().toolPrefix
-        return name.startsWith(prefix) && _state.get().online
-    }
-
-    /** Returns the current tool prefix (mt_apk_ or np_). */
-    fun bridgedPrefix(): String = _state.get().toolPrefix
-
+    /**
+     * Remove a bridge connection by URL.
+     */
     @Synchronized
-    fun callTool(name: String, arguments: JSONObject): JSONObject {
-        val st = _state.get()
-        if (!st.online || st.url.isBlank()) {
-            return errorResult(name, "APK MCP is offline or not configured")
-        }
-        val params = JSONObject().put("name", name).put("arguments", arguments)
-        return try {
-            val req = buildJsonRpc(st.url, "tools/call", params, id = nextId())
-            val resp = post(req)
-            // remote returns a JSON-RPC envelope; unwrap returnContent into our shape
-            parseToolResult(resp)
-        } catch (e: Exception) {
-            errorResult(name, "forward failed: ${e.message}")
-        }
+    fun removeBridge(url: String) {
+        connections.removeAll { it.url == url }
+        val configs = settings.apkMcpConfigs.toMutableList()
+        configs.removeAll { it.url == url }
+        settings.apkMcpConfigs = configs
     }
 
-    @Volatile private var healthThread: Thread? = null
-    @Volatile private var healthStop = false
+    /** Lightweight liveness ping for all connections. */
+    @Synchronized
+    fun ping(): State {
+        syncConnectionsFromSettings()
+        if (connections.isEmpty()) return State()
+        val exec = java.util.concurrent.Executors.newFixedThreadPool(
+            connections.size.coerceIn(1, 4)
+        )
+        try {
+            val results = connections.map { conn -> exec.submit<State> { conn.ping() } }
+            results.forEach { it.get() }
+        } finally {
+            exec.shutdown()
+        }
+        return connections.firstOrNull()?.state ?: State()
+    }
 
-    fun startHealthMonitor(intervalMs: Long = 30_000) {
-        stopHealthMonitor()
-        healthStop = false
-        healthThread = Thread({
-            while (!healthStop && !Thread.currentThread().isInterrupted) {
-                try {
-                    Thread.sleep(intervalMs)
-                } catch (_: InterruptedException) {
-                    break
-                }
-                if (healthStop) break
-                val url = settings.apkMcpUrl
-                if (url.isBlank()) continue
-                try {
-                    val req = buildJsonRpc(url, "tools/list", JSONObject(), id = 1)
-                    val resp = post(req)
-                    val parsed = parseTools(resp)
-                    val prefix = parsed.firstOrNull { it.name.startsWith(MT_PREFIX) }?.let { MT_PREFIX }
-                        ?: parsed.firstOrNull { it.name.startsWith(NP_PREFIX) }?.let { NP_PREFIX }
-                    if (prefix != null) {
-                        val cur = _state.get()
-                        _state.set(State(url = url, online = true, lastError = "", tools = parsed, toolPrefix = prefix, lastCheckedAt = System.currentTimeMillis()))
-                        if (!cur.online) AppLog.i("apk-mcp health: back online (${parsed.size} tools, prefix=$prefix)")
-                    }
-                } catch (e: Exception) {
-                    val cur = _state.get()
-                    if (cur.online) {
-                        _state.set(State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName, tools = emptyList(), lastCheckedAt = System.currentTimeMillis()))
-                        AppLog.w("apk-mcp health: marked offline (${e.message})")
-                    }
-                }
+    /** Collect all tools from all online bridge connections. */
+    fun mergedTools(): List<ToolDef> {
+        val all = mutableListOf<ToolDef>()
+        for (conn in connections) {
+            val st = conn.state
+            if (st.online) {
+                all.addAll(st.tools.filter { it.name.startsWith(st.toolPrefix) })
             }
-        }, "apk-mcp-health").apply { isDaemon = true; start() }
-    }
-
-    fun stopHealthMonitor() {
-        healthStop = true
-        healthThread?.interrupt()
-        healthThread = null
-    }
-
-    fun snapshotJson(): JSONObject {
-        val st = _state.get()
-        return JSONObject().apply {
-            put("configured", st.url.isNotBlank())
-            put("url", st.url)
-            put("online", st.online)
-            put("toolPrefix", st.toolPrefix)
-            put("toolCount", st.tools.size)
-            put("lastError", st.lastError)
-            put("lastCheckedAt", st.lastCheckedAt)
-            put("lastLatencyMs", st.lastLatencyMs)
-            put("avgLatencyMs", st.avgLatencyMs())
-            put("maxLatencyMs", st.maxLatencyMs)
-            put("probes", st.probes)
-            put("probeFailures", st.probeFailures)
-            put("lossRate", st.lossRate())
-            put("tools", JSONArray().apply { st.tools.forEach { put(it.name) } })
         }
+        return all
     }
 
-    private fun buildJsonRpc(url: String, method: String, params: JSONObject, id: Int): Request {
-        val body = JSONObject()
-            .put("jsonrpc", "2.0")
-            .put("id", id)
-            .put("method", method)
-            .put("params", params)
-            .toString()
-        val builder = Request.Builder().url(url).post(body.toRequestBody("application/json".toMediaType()))
-        settings.apkMcpToken.ifNotBlank { builder.safeHeader("Authorization", "Bearer $it") }
-        return builder.build()
-    }
-
-    private fun post(req: Request): String {
-        client.newCall(req).execute().use { r ->
-            val body = r.body?.string().orEmpty()
-            if (!r.isSuccessful) throw IllegalStateException("HTTP ${r.code}")
-            return body
+    /** Check if a tool name is handled by any bridged connection. */
+    fun isBridgedTool(name: String): Boolean {
+        for (conn in connections) {
+            val st = conn.state
+            if (st.online && name.startsWith(st.toolPrefix)) return true
         }
+        return false
     }
 
-    private fun parseTools(body: String): List<ToolDef> {
-        val root = JSONObject(body)
-        val result = root.opt("result") as? JSONObject ?: return emptyList()
-        val tools = result.optJSONArray("tools") ?: return emptyList()
-        val out = ArrayList<ToolDef>(tools.length())
-        for (i in 0 until tools.length()) {
-            val t = tools.getJSONObject(i)
-            out.add(
-                ToolDef(
-                    name = t.optString("name"),
-                    title = t.optString("title").takeIf { it.isNotBlank() },
-                    description = t.optString("description").takeIf { it.isNotBlank() },
-                    inputSchema = t.optJSONObject("inputSchema"),
-                    outputSchema = t.optJSONObject("outputSchema"),
-                )
-            )
+    /** Returns the prefix of the first online bridge, or the first connection's prefix. */
+    fun bridgedPrefix(): String {
+        for (conn in connections) {
+            val st = conn.state
+            if (st.online) return st.toolPrefix
         }
-        return out
+        return connections.firstOrNull()?.state?.toolPrefix ?: MT_PREFIX
     }
 
-    private fun parseToolResult(body: String): JSONObject {
-        val root = JSONObject(body)
-        val result = root.opt("result")
-        return (result as? JSONObject) ?: JSONObject().put("raw", body)
+    /** Get all known prefixes from all connections (both online and offline). */
+    fun allPrefixes(): List<String> {
+        val prefixes = mutableSetOf<String>()
+        for (conn in connections) {
+            val st = conn.state
+            if (st.online) prefixes.add(st.toolPrefix)
+        }
+        return prefixes.toList()
     }
 
-    private fun errorResult(name: String, msg: String): JSONObject {
-        return JSONObject().put("content", JSONArray().put(JSONObject().put("type", "text").put("text", "APK MCP error [$name]: $msg")))
+    /**
+     * Call a tool on the correct bridge connection based on the tool name prefix.
+     */
+    fun callTool(name: String, arguments: JSONObject): JSONObject {
+        // Find the connection whose prefix matches this tool name
+        for (conn in connections) {
+            val st = conn.state
+            if (st.online && name.startsWith(st.toolPrefix)) {
+                return conn.callTool(name, arguments)
+            }
+        }
+        // If no online connection matches, try finding any connection that was configured for this prefix
+        val offlineMsg = StringBuilder("APK MCP bridge is offline. Configured: ")
+        for (conn in connections) {
+            offlineMsg.append("${conn.url} (${conn.state.online}) ")
+        }
+        if (connections.isEmpty()) offlineMsg.append("(none)")
+        return JSONObject().put("content", JSONArray().put(JSONObject().put("type", "text").put("text", offlineMsg.toString())))
             .put("isError", true)
             .put("source", "apk-mcp-bridge")
     }
 
-    private fun nextId(): Int = idCounter++
+    @Synchronized
+    fun startHealthMonitor(intervalMs: Long = 30_000) {
+        for (conn in connections) {
+            conn.startHealthMonitor(intervalMs)
+        }
+    }
+
+    @Synchronized
+    fun stopHealthMonitor() {
+        for (conn in connections) {
+            conn.stopHealthMonitor()
+        }
+    }
+
+    fun snapshotJson(): JSONObject {
+        val configs = settings.apkMcpConfigs
+        val bridges = JSONArray()
+        for (config in configs) {
+            val conn = connections.firstOrNull { it.url == config.url }
+            val st = conn?.state ?: State(url = config.url)
+            bridges.put(JSONObject()
+                .put("url", config.url)
+                .put("online", st.online)
+                .put("toolPrefix", st.toolPrefix)
+                .put("toolCount", st.tools.size)
+                .put("lastError", st.lastError)
+                .put("lastCheckedAt", st.lastCheckedAt)
+                .put("lastLatencyMs", st.lastLatencyMs)
+                .put("avgLatencyMs", st.avgLatencyMs())
+                .put("maxLatencyMs", st.maxLatencyMs)
+                .put("probes", st.probes)
+                .put("probeFailures", st.probeFailures)
+                .put("lossRate", st.lossRate())
+                .put("tools", JSONArray().apply { st.tools.forEach { put(it.name) } })
+            )
+        }
+        val firstOnline = connections.firstOrNull { it.state.online }
+        val first = connections.firstOrNull()
+        return JSONObject().apply {
+            put("configured", configs.isNotEmpty())
+            put("bridgeCount", configs.size)
+            put("onlineCount", connections.count { it.state.online })
+            put("bridges", bridges)
+            // Backward compat fields
+            put("url", first?.url ?: "")
+            put("online", firstOnline?.state?.online == true)
+            put("toolPrefix", firstOnline?.state?.toolPrefix ?: first?.state?.toolPrefix ?: "")
+            put("toolCount", firstOnline?.state?.tools?.size ?: 0)
+            put("lastError", firstOnline?.state?.lastError ?: first?.state?.lastError ?: "")
+            put("lastCheckedAt", firstOnline?.state?.lastCheckedAt ?: first?.state?.lastCheckedAt ?: 0)
+            put("lastLatencyMs", firstOnline?.state?.lastLatencyMs ?: first?.state?.lastLatencyMs ?: 0)
+            put("avgLatencyMs", firstOnline?.state?.avgLatencyMs() ?: first?.state?.avgLatencyMs() ?: 0)
+            put("maxLatencyMs", firstOnline?.state?.maxLatencyMs ?: first?.state?.maxLatencyMs ?: 0)
+            put("probes", firstOnline?.state?.probes ?: first?.state?.probes ?: 0)
+            put("probeFailures", firstOnline?.state?.probeFailures ?: first?.state?.probeFailures ?: 0)
+            put("lossRate", firstOnline?.state?.lossRate() ?: first?.state?.lossRate() ?: 0.0)
+            put("tools", JSONArray().apply {
+                (firstOnline?.state?.tools ?: first?.state?.tools ?: emptyList()).forEach { put(it.name) }
+            })
+        }
+    }
 
     companion object {
         const val DEFAULT_PORT = 8787
@@ -325,7 +536,13 @@ class ApkMcpBridge(private val settings: SettingsStore) {
         const val MT_PREFIX = "mt_apk_"
         const val NP_PREFIX = "np_"
         val KNOWN_PREFIXES = listOf(MT_PREFIX, NP_PREFIX)
-        private var idCounter = 100
+        private val connIdCounter = AtomicInteger(1000)
+
+        fun prefixLabel(prefix: String?): String = when (prefix) {
+            MT_PREFIX -> "MT Manager"
+            NP_PREFIX -> "NP Manager"
+            else -> "Unknown"
+        }
     }
 }
 

--- a/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
@@ -348,12 +348,11 @@ class ApkMcpBridge(private val settings: SettingsStore) {
             connections.size.coerceIn(1, 4)
         )
         try {
-            val snapshot = connections.map { conn -> conn.state }
             val results = connections.map { conn ->
                 exec.submit<State> { conn.probe() }
             }
             results.forEach { it.get() }
-            return snapshot.firstOrNull() ?: State()
+            return connections.firstOrNull()?.state ?: State()
         } finally {
             exec.shutdown()
         }

--- a/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
@@ -452,13 +452,78 @@ class SettingsStore(context: Context) {
         set(value) = prefs.edit().putString("tunnelLogLevel", if (value in setOf("debug", "info", "warn", "error", "fatal")) value else "info").apply()
 
     // ---- APK MCP bridge ----
+    /** Single bridge URL (legacy, maps to first entry in [apkMcpConfigs]). */
     var apkMcpUrl: String
-        get() = prefs.getString("apkMcpUrl", "") ?: ""
-        set(value) = prefs.edit().putString("apkMcpUrl", value.trim()).apply()
+        get() {
+            val configs = apkMcpConfigs
+            return configs.firstOrNull()?.url ?: ""
+        }
+        set(value) {
+            val configs = apkMcpConfigs.toMutableList()
+            if (configs.isEmpty()) {
+                configs.add(BridgeConfig(value.trim(), apkMcpToken))
+            } else {
+                configs[0] = configs[0].copy(url = value.trim())
+            }
+            apkMcpConfigs = configs
+        }
 
+    /** Single bridge token (legacy, maps to first entry in [apkMcpConfigs]). */
     var apkMcpToken: String
-        get() = sanitizeCredential(prefs.getString("apkMcpToken", "").orEmpty())
-        set(value) = prefs.edit().putString("apkMcpToken", sanitizeCredential(value)).apply()
+        get() {
+            val configs = apkMcpConfigs
+            return configs.firstOrNull()?.token ?: ""
+        }
+        set(value) {
+            val configs = apkMcpConfigs.toMutableList()
+            if (configs.isEmpty()) {
+                configs.add(BridgeConfig(apkMcpUrl, sanitizeCredential(value)))
+            } else {
+                configs[0] = configs[0].copy(token = sanitizeCredential(value))
+            }
+            apkMcpConfigs = configs
+        }
+
+    data class BridgeConfig(val url: String, val token: String = "")
+
+    /** Multiple bridge configurations as a JSON array of {"url","token"} objects. */
+    var apkMcpConfigs: List<BridgeConfig>
+        get() {
+            val raw = prefs.getString("apkMcpConfigs", "") ?: ""
+            if (raw.isBlank()) {
+                // Migration: read legacy single URL+token
+                val legacyUrl = prefs.getString("apkMcpUrl", "") ?: ""
+                return if (legacyUrl.isNotBlank()) {
+                    val legacyToken = sanitizeCredential(prefs.getString("apkMcpToken", "").orEmpty())
+                    listOf(BridgeConfig(legacyUrl, legacyToken))
+                } else emptyList()
+            }
+            return try {
+                val arr = org.json.JSONArray(raw)
+                (0 until arr.length()).map { i ->
+                    val obj = arr.getJSONObject(i)
+                    BridgeConfig(
+                        url = obj.optString("url", ""),
+                        token = sanitizeCredential(obj.optString("token", "")),
+                    )
+                }.filter { it.url.isNotBlank() }
+            } catch (_: Exception) { emptyList() }
+        }
+        set(value) {
+            val arr = org.json.JSONArray()
+            value.forEach { config ->
+                arr.put(org.json.JSONObject()
+                    .put("url", config.url.trim())
+                    .put("token", config.token))
+            }
+            prefs.edit().putString("apkMcpConfigs", arr.toString()).apply()
+            // Keep legacy fields in sync for backward compatibility
+            val first = value.firstOrNull()
+            prefs.edit()
+                .putString("apkMcpUrl", first?.url?.trim() ?: "")
+                .putString("apkMcpToken", first?.token?.let { sanitizeCredential(it) } ?: "")
+                .apply()
+        }
 
     var apkMcpAutoProbe: Boolean
         get() = prefs.getBoolean("apkMcpAutoProbe", false)
@@ -615,6 +680,11 @@ class SettingsStore(context: Context) {
             .put("apkBridge", org.json.JSONObject()
                 .put("apkMcpUrl", apkMcpUrl)
                 .put("apkMcpToken", mask(apkMcpToken))
+                .put("apkMcpConfigs", org.json.JSONArray().apply {
+                    apkMcpConfigs.forEach { c ->
+                        put(org.json.JSONObject().put("url", c.url).put("token", mask(c.token)))
+                    }
+                })
                 .put("apkMcpAutoProbe", apkMcpAutoProbe)
                 .put("apkMcpMergeTools", apkMcpMergeTools)
                 .put("apkMcpProbeTimeoutMs", apkMcpProbeTimeoutMs))
@@ -739,6 +809,24 @@ class SettingsStore(context: Context) {
         val apk = obj("apkBridge") ?: patch
         applyStr(apk, "apkMcpUrl") { apkMcpUrl = it }
         if (allowSecrets) applyStr(apk, "apkMcpToken") { apkMcpToken = it }
+        // Support setting multiple bridge configs via JSON array
+        if (apk.has("apkMcpConfigs") && !apk.isNull("apkMcpConfigs")) {
+            try {
+                val arr = apk.optJSONArray("apkMcpConfigs")
+                if (arr != null && arr.length() > 0) {
+                    val configs = mutableListOf<BridgeConfig>()
+                    for (i in 0 until arr.length()) {
+                        val obj = arr.getJSONObject(i)
+                        val url = obj.optString("url", "").trim()
+                        if (url.isNotBlank()) {
+                            val token = if (allowSecrets) obj.optString("token", "") else ""
+                            configs.add(BridgeConfig(url, token))
+                        }
+                    }
+                    if (configs.isNotEmpty()) apkMcpConfigs = configs
+                }
+            } catch (_: Exception) {}
+        }
         applyBool(apk, "apkMcpAutoProbe") { apkMcpAutoProbe = it }
         applyBool(apk, "apkMcpMergeTools") { apkMcpMergeTools = it }
         applyInt(apk, "apkMcpProbeTimeoutMs") { apkMcpProbeTimeoutMs = it }

--- a/app/src/main/java/com/soreverse/mcp/mcp/McpHttpServer.kt
+++ b/app/src/main/java/com/soreverse/mcp/mcp/McpHttpServer.kt
@@ -90,8 +90,10 @@ class McpHttpServer(private val context: Context, private val port: Int, private
     fun ensureBridgeProbed() {
         val s = SettingsStore(context)
         if (!s.apkMcpAutoProbe) return
-        if (s.apkMcpUrl.isNotBlank()) {
-            if (!apkBridge.state().online) Thread { apkBridge.probe() }.start()
+        val configs = s.apkMcpConfigs
+        if (configs.isNotEmpty()) {
+            val st = apkBridge.state()
+            if (!st.online) Thread { apkBridge.probe() }.start()
         } else {
             Thread { apkBridge.autoDiscover(ApkMcpBridge.DEFAULT_PORT) }.start()
         }
@@ -342,7 +344,11 @@ class McpHttpServer(private val context: Context, private val port: Int, private
                 .put("total", ToolCatalog.ALL.count { it.meta.category == cat })
                 .put("advertised", advertisedCountOf(advertised, cat)))
         }
-        val apkBridged = (0 until advertised.length()).count { advertised.getJSONObject(it).optString("name").startsWith(apkBridge.bridgedPrefix()) }
+        val apkPrefixes = apkBridge.allPrefixes().toSet()
+        val apkBridged = (0 until advertised.length()).count {
+            val name = advertised.getJSONObject(it).optString("name")
+            apkPrefixes.any { name.startsWith(it) }
+        }
         return ok(JSONObject()
             .put("totalCatalogCount", total)
             .put("advertisedCount", advertisedCount)
@@ -355,8 +361,10 @@ class McpHttpServer(private val context: Context, private val port: Int, private
 
     private fun advertisedCountOf(arr: JSONArray, category: String): Int {
         var count = 0
+        val apkPrefixes = apkBridge.allPrefixes()
         for (i in 0 until arr.length()) {
-            if (ToolCatalog.categoryOf(arr.getJSONObject(i).optString("name")) == category || (category == "apk-bridge" && arr.getJSONObject(i).optString("name").startsWith(apkBridge.bridgedPrefix()))) count++
+            val name = arr.getJSONObject(i).optString("name")
+            if (ToolCatalog.categoryOf(name) == category || (category == "apk-bridge" && apkPrefixes.any { name.startsWith(it) })) count++
         }
         return count
     }
@@ -448,7 +456,7 @@ class McpHttpServer(private val context: Context, private val port: Int, private
         val handler = ToolCatalog.byName[name]
         val payload = if (handler != null) {
             handler.handle(ctx, args)
-        } else if (name.startsWith(apkBridge.bridgedPrefix())) {
+        } else if (apkBridge.isBridgedTool(name)) {
             if (apkBridge.isBridgedTool(name)) apkBridge.callTool(name, args) else err("APK_MCP_OFFLINE", "APK MCP bridge is offline. Run system_control (action=apk_probe) after starting an APK MCP server.", "tool", name)
         } else {
             JSONObject().put("ok", false).put("error", JSONObject().put("code", "TOOL_NOT_FOUND").put("message", name))
@@ -510,9 +518,12 @@ class McpHttpServer(private val context: Context, private val port: Int, private
         val out = JSONArray()
         ToolCatalog.ALL.forEach { handler -> out.put(ToolCatalog.toolDescriptor(handler, includeCategory)) }
         if (settings.apkMcpMergeTools) {
-            val state = apkBridge.state()
-            val toolsToShow = if (state.online) state.tools else if (settings.apkMcpAutoProbe) apkBridge.probe().tools else emptyList()
-            toolsToShow.filter { it.name.startsWith(apkBridge.bridgedPrefix()) }.forEach { td ->
+            val merged = apkBridge.mergedTools()
+            // If no cached tools, try probing
+            val toolsToShow = if (merged.isNotEmpty()) merged
+                else if (settings.apkMcpAutoProbe) apkBridge.probe().let { apkBridge.mergedTools() }
+                else emptyList()
+            toolsToShow.forEach { td ->
                 val schema = td.inputSchema ?: JSONObject().put("type", "object").put("properties", JSONObject())
                 val obj = JSONObject()
                     .put("name", td.name)
@@ -553,22 +564,43 @@ class McpHttpServer(private val context: Context, private val port: Int, private
     private fun sysStatus(probe: Boolean): JSONObject {
         if (probe) apkBridge.probe()
         val s = SettingsStore(context)
+        val snapshot = apkBridge.snapshotJson()
+        val onlineBridges = snapshot.optJSONArray("bridges")
+        val onlineBridgeCount = snapshot.optInt("onlineCount")
+        val onlinePrefixes = apkBridge.allPrefixes()
+        val integrationOnline = onlinePrefixes.isNotEmpty()
+        val integrationHint = when {
+            onlineBridgeCount == 0 -> "APK MCP is offline. Install MT Manager or NP Manager, enable the APK MCP feature, keep it running in background, then set its /mcp URL in settings and call system_control (action=apk_probe)."
+            onlineBridgeCount == 1 -> {
+                val prefix = apkBridge.bridgedPrefix()
+                val label = ApkMcpBridge.prefixLabel(prefix)
+                if (prefix == ApkMcpBridge.MT_PREFIX)
+                    "MT Manager APK MCP is online. Use MT Manager's mt_apk_* capabilities for APK open / smali+axml edit / signed APK build, and use this app as the SO assistant for so_open/analyze_*/edit_* on embedded lib/*/*.so. Workflow: mt_apk_open -> mt_apk_list (lib/<abi>) -> so_open -> analyze_*/edit_* -> build_so."
+                else
+                    "$label APK MCP is online. Use ${prefix}* capabilities for APK open / smali+axml edit / signed APK build, and use this app as the SO assistant for so_open/analyze_*/edit_* on embedded lib/*/*.so. Workflow: ${prefix}open -> ${prefix}list (lib/<abi>) -> so_open -> analyze_*/edit_* -> build_so."
+            }
+            else -> {
+                val labels = onlinePrefixes.joinToString(" + ") { ApkMcpBridge.prefixLabel(it) }
+                val workflowLines = onlinePrefixes.map { p ->
+                    val label = ApkMcpBridge.prefixLabel(p)
+                    "  $label (${p}*): ${p}open -> ${p}list (lib/<abi>) -> so_open -> analyze_*/edit_* -> build_so"
+                }.joinToString("\n")
+                "$onlineBridgeCount APK MCP bridges online ($labels). Each bridge exposes its own tool prefix and routes independently. Use the right tool prefix for each APK. Workflows:\n$workflowLines"
+            }
+        }
         return ok(JSONObject()
             .put("soMcp", JSONObject().put("running", engine != null).put("host", host).put("port", port))
             .put("runtime", runtimeInfo())
             .put("nativeBackends", nativeBackendStatus())
-            .put("apkMcp", apkBridge.snapshotJson())
+            .put("apkMcp", snapshot)
             .put("tunnel", tunnel.snapshotJson())
             .put("integration", JSONObject()
-                .put("online", apkBridge.state().online)
+                .put("online", integrationOnline)
+                .put("onlineCount", onlineBridgeCount)
+                .put("prefixes", JSONArray(onlinePrefixes))
+                .put("labels", JSONArray(onlinePrefixes.map { ApkMcpBridge.prefixLabel(it) }))
                 .put("apkMcpUrl", s.apkMcpUrl)
-                .put("hint", if (apkBridge.state().online) {
-                    val prefix = apkBridge.bridgedPrefix()
-                    if (prefix == ApkMcpBridge.MT_PREFIX)
-                        "MT Manager APK MCP is online. Use MT Manager's mt_apk_* capabilities for APK open / smali+axml edit / signed APK build, and use this app as the SO assistant for so_open/analyze_*/edit_* on embedded lib/*/*.so. Workflow: mt_apk_open -> mt_apk_list (lib/<abi>) -> so_open -> analyze_*/edit_* -> build_so."
-                    else
-                        "NP Manager APK MCP is online. Use NP Manager's np_* capabilities for APK open / smali+axml edit / signed APK build, and use this app as the SO assistant for so_open/analyze_*/edit_* on embedded lib/*/*.so. Workflow: np_open -> np_list (lib/<abi>) -> so_open -> analyze_*/edit_* -> build_so."
-                } else "APK MCP is offline. Install MT Manager or NP Manager, enable the APK MCP feature, keep it running in background, then set its /mcp URL in settings and call system_control (action=apk_probe)."))
+                .put("hint", integrationHint))
             .put("cloudflaredAvailable", tunnel.binary()?.exists() == true)
         )
     }
@@ -627,7 +659,7 @@ class McpHttpServer(private val context: Context, private val port: Int, private
         }
         if (settings.apkMcpMergeTools && apkBridge.state().online) {
             val apkNames = JSONArray()
-            apkBridge.state().tools.filter { it.name.startsWith(apkBridge.bridgedPrefix()) }.forEach {
+            apkBridge.mergedTools().forEach {
                 apkNames.put(JSONObject().put("name", it.name).put("cls", "apk").put("advertised", true))
             }
             catMap.put("apk-bridge", JSONObject()
@@ -748,7 +780,7 @@ class McpHttpServer(private val context: Context, private val port: Int, private
         }
         if (settings.apkMcpMergeTools && (category.isBlank() || category == "apk-bridge") && apkBridge.state().online) {
             val qLower = q
-            apkBridge.state().tools.filter { it.name.startsWith(apkBridge.bridgedPrefix()) }
+            apkBridge.mergedTools()
                 .filter { !hasQuery || (it.name + "\n" + (it.description ?: "")).lowercase().contains(qLower) }
                 .forEach { td ->
                     if (!grouped.has("apk-bridge")) grouped.put("apk-bridge", JSONArray())
@@ -787,17 +819,24 @@ class McpHttpServer(private val context: Context, private val port: Int, private
      * dynamic APK-bridge tools are added, or if operators explicitly disable
      * tools through policy.
      */
-    /** Returns a human-readable label for the current APK MCP bridge (MT Manager or NP Manager). */
-    private fun bridgeLabel(): String = if (apkBridge.bridgedPrefix() == ApkMcpBridge.NP_PREFIX) "NP Manager" else "MT Manager"
+    /** Returns a human-readable label for all online APK MCP bridges. */
+    private fun bridgeLabel(): String {
+        val prefixes = apkBridge.allPrefixes()
+        if (prefixes.isEmpty()) return "MT/NP Manager"
+        return prefixes.joinToString(" + ") {
+            ApkMcpBridge.prefixLabel(it)
+        }
+    }
 
     private fun advertisedTools(): JSONArray {
         val full = tools()
         if (full.length() <= ToolCatalog.ALL.size + 64) return full
         val out = JSONArray()
+        val apkPrefixes = apkBridge.allPrefixes()
         for (i in 0 until full.length()) {
             val t = full.getJSONObject(i)
             val name = t.optString("name")
-            if (!name.startsWith(apkBridge.bridgedPrefix()) || out.length() < ToolCatalog.ALL.size + 64) out.put(t)
+            if (!apkPrefixes.any { name.startsWith(it) } || out.length() < ToolCatalog.ALL.size + 64) out.put(t)
         }
         return out
     }


### PR DESCRIPTION
Allow connecting to multiple APK MCP servers (e.g. MT Manager + NP Manager) at the same time, instead of only one.

- SettingsStore: new `apkMcpConfigs: List<BridgeConfig>` with legacy migration
- ApkMcpBridge: `CopyOnWriteArrayList<BridgeConnection>`, per-bridge client/thread, parallel probe/ping
- McpHttpServer: merged tools/list, multi-bridge sysStatus (onlineCount, per-prefix hints)
- SettingsApkBridgePage: list + add/remove UI with status indicators
- ServiceTab: home tab reflects all online bridges via mergedTools()