### PR TITLE
feat(np-manager): add SSE transport support for NP Manager bridge

### DIFF
--- a/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
@@ -7,10 +7,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.sse.EventSource
-import okhttp3.sse.EventSourceListener
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -57,7 +54,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
     /**
      * Internal representation of a single bridge connection.
      */
-    private class BridgeConnection(val url: String, val token: String, val transport: String = "auto") {
+    private class BridgeConnection(val url: String, val token: String) {
         @Volatile var state: State = State(url = url)
         private val client: OkHttpClient by lazy {
             OkHttpClient.Builder()
@@ -69,99 +66,10 @@ class ApkMcpBridge(private val settings: SettingsStore) {
         @Volatile private var healthThread: Thread? = null
         @Volatile private var healthStop = false
 
-        private fun shouldUseSse(): Boolean {
-            return when (transport) {
-                "sse" -> true
-                "http" -> false
-                "auto" -> url.contains(":8788") || url.contains("/np") || state.toolPrefix == NP_PREFIX
-                else -> false
-            }
-        }
-
         @Synchronized
         fun probe(timeoutMs: Int = 8000): State {
-            return if (shouldUseSse()) {
-                probeSse(timeoutMs)
-            } else {
-                probeHttp(timeoutMs)
-            }
-        }
-
-        @Synchronized
-        fun ping(): State {
-            return if (shouldUseSse()) {
-                pingSse()
-            } else {
-                pingHttp()
-            }
-        }
-
-        fun callTool(name: String, arguments: JSONObject): JSONObject {
-            val st = state
-            if (!st.online || st.url.isBlank()) {
-                return errorResult(name, "APK MCP $url is offline or not configured")
-            }
-            val params = JSONObject().put("name", name).put("arguments", arguments)
-            return try {
-                if (shouldUseSse()) {
-                    val sseClient = SseClient(url, token)
-                    val resp = sseClient.callTool("tools/call", params, timeoutMs = 20000)
-                    parseToolResult(resp)
-                } else {
-                    val req = buildJsonRpc(url, "tools/call", params, id = ApkMcpBridge.connIdCounter.incrementAndGet())
-                    val resp = post(req)
-                    parseToolResult(resp)
-                }
-            } catch (e: Exception) {
-                errorResult(name, "forward failed: ${e.message}")
-            }
-        }
-
-        fun startHealthMonitor(intervalMs: Long = 30_000) {
-            stopHealthMonitor()
-            healthStop = false
-            healthThread = Thread({
-                while (!healthStop && !Thread.currentThread().isInterrupted) {
-                    try {
-                        Thread.sleep(intervalMs)
-                    } catch (_: InterruptedException) { break }
-                    if (healthStop) break
-                    try {
-                        val start = System.nanoTime()
-                        val tools = if (shouldUseSse()) {
-                            SseClient(url, token).listTools(timeoutMs = 8000)
-                        } else {
-                            val req = buildJsonRpc(url, "tools/list", JSONObject(), id = ApkMcpBridge.connIdCounter.incrementAndGet())
-                            val resp = post(req)
-                            parseTools(resp)
-                        }
-                        val latencyMs = (System.nanoTime() - start) / 1_000_000
-                        val prefix = detectPrefix(tools)
-                        if (prefix != null) {
-                            val cur = state
-                            state = State(url = url, online = true, lastError = "", tools = tools, toolPrefix = prefix, lastCheckedAt = System.currentTimeMillis(), lastLatencyMs = latencyMs)
-                            if (!cur.online) AppLog.i("apk-mcp health: $url back online (${tools.size} tools, prefix=$prefix)")
-                        }
-                    } catch (e: Exception) {
-                        val cur = state
-                        if (cur.online) {
-                            state = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName, tools = emptyList(), lastCheckedAt = System.currentTimeMillis())
-                            AppLog.w("apk-mcp health: $url marked offline (${e.message})")
-                        }
-                    }
-                }
-            }, "apk-mcp-health-$url").apply { isDaemon = true; start() }
-        }
-
-        fun stopHealthMonitor() {
-            healthStop = true
-            healthThread?.interrupt()
-            healthThread = null
-        }
-
-        private fun probeHttp(timeoutMs: Int): State {
-            return try {
-                val req = buildJsonRpc(url, "tools/list", JSONObject(), id = ApkMcpBridge.connIdCounter.incrementAndGet())
+            try {
+                val req = buildJsonRpc(url, "tools/list", JSONObject(), id = connIdCounter.incrementAndGet())
                 val start = System.nanoTime()
                 val resp = post(req)
                 val latencyMs = (System.nanoTime() - start) / 1_000_000
@@ -196,9 +104,10 @@ class ApkMcpBridge(private val settings: SettingsStore) {
             }
         }
 
-        private fun pingHttp(): State {
+        @Synchronized
+        fun ping(): State {
             return try {
-                val req = buildJsonRpc(url, "initialize", JSONObject().put("client", "somcp-ping"), id = ApkMcpBridge.connIdCounter.incrementAndGet())
+                val req = buildJsonRpc(url, "initialize", JSONObject().put("client", "somcp-ping"), id = connIdCounter.incrementAndGet())
                 val start = System.nanoTime()
                 post(req)
                 val latencyMs = (System.nanoTime() - start) / 1_000_000
@@ -224,68 +133,55 @@ class ApkMcpBridge(private val settings: SettingsStore) {
             }
         }
 
-        private fun probeSse(timeoutMs: Int): State {
+        fun callTool(name: String, arguments: JSONObject): JSONObject {
+            val st = state
+            if (!st.online || st.url.isBlank()) {
+                return errorResult(name, "APK MCP $url is offline or not configured")
+            }
+            val params = JSONObject().put("name", name).put("arguments", arguments)
             return try {
-                val sseClient = SseClient(url, token)
-                val start = System.nanoTime()
-                val tools = sseClient.listTools(timeoutMs)
-                val latencyMs = (System.nanoTime() - start) / 1_000_000
-                val prefix = detectPrefix(tools)
-                val prev = state
-                val s = State(
-                    url = url,
-                    online = true,
-                    lastError = "",
-                    tools = tools,
-                    toolPrefix = prefix ?: prev.toolPrefix,
-                    lastCheckedAt = System.currentTimeMillis(),
-                    lastLatencyMs = latencyMs,
-                    probes = prev.probes + 1,
-                    probeFailures = prev.probeFailures,
-                    totalLatencyMs = prev.totalLatencyMs + latencyMs,
-                    maxLatencyMs = maxOf(prev.maxLatencyMs, latencyMs),
-                )
-                state = s
-                val label = prefixLabel(prefix)
-                AppLog.i("apk-mcp bridge online (sse): ${tools.size} tools from $url ($label, ${latencyMs}ms)")
-                s
+                val req = buildJsonRpc(url, "tools/call", params, id = connIdCounter.incrementAndGet())
+                val resp = post(req)
+                parseToolResult(resp)
             } catch (e: Exception) {
-                val prev = state
-                val s = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName,
-                    probes = prev.probes + 1, probeFailures = prev.probeFailures + 1,
-                    totalLatencyMs = prev.totalLatencyMs, maxLatencyMs = prev.maxLatencyMs)
-                state = s
-                AppLog.w("apk-mcp probe failed (sse): $url ${e.message}")
-                s
+                errorResult(name, "forward failed: ${e.message}")
             }
         }
 
-        private fun pingSse(): State {
-            return try {
-                val sseClient = SseClient(url, token)
-                val start = System.nanoTime()
-                sseClient.ping(timeoutMs = 8000)
-                val latencyMs = (System.nanoTime() - start) / 1_000_000
-                val prev = state
-                val s = if (!prev.online) {
-                    prev.copy(lastLatencyMs = latencyMs, lastCheckedAt = System.currentTimeMillis(),
-                        probes = prev.probes + 1, lastError = "", online = false, tools = prev.tools)
-                } else {
-                    State(url = url, online = true, lastError = "", tools = prev.tools,
-                        lastCheckedAt = System.currentTimeMillis(), lastLatencyMs = latencyMs,
-                        probes = prev.probes + 1, probeFailures = prev.probeFailures,
-                        totalLatencyMs = prev.totalLatencyMs + latencyMs, maxLatencyMs = maxOf(prev.maxLatencyMs, latencyMs))
+        fun startHealthMonitor(intervalMs: Long = 30_000) {
+            stopHealthMonitor()
+            healthStop = false
+            healthThread = Thread({
+                while (!healthStop && !Thread.currentThread().isInterrupted) {
+                    try {
+                        Thread.sleep(intervalMs)
+                    } catch (_: InterruptedException) { break }
+                    if (healthStop) break
+                    try {
+                        val req = buildJsonRpc(url, "tools/list", JSONObject(), id = connIdCounter.incrementAndGet())
+                        val resp = post(req)
+                        val parsed = parseTools(resp)
+                        val prefix = detectPrefix(parsed)
+                        if (prefix != null) {
+                            val cur = state
+                            state = State(url = url, online = true, lastError = "", tools = parsed, toolPrefix = prefix, lastCheckedAt = System.currentTimeMillis())
+                            if (!cur.online) AppLog.i("apk-mcp health: $url back online (${parsed.size} tools, prefix=$prefix)")
+                        }
+                    } catch (e: Exception) {
+                        val cur = state
+                        if (cur.online) {
+                            state = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName, tools = emptyList(), lastCheckedAt = System.currentTimeMillis())
+                            AppLog.w("apk-mcp health: $url marked offline (${e.message})")
+                        }
+                    }
                 }
-                state = s
-                s
-            } catch (e: Exception) {
-                val prev = state
-                val s = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName,
-                    probes = prev.probes + 1, probeFailures = prev.probeFailures + 1,
-                    totalLatencyMs = prev.totalLatencyMs, maxLatencyMs = prev.maxLatencyMs)
-                state = s
-                s
-            }
+            }, "apk-mcp-health-$url").apply { isDaemon = true; start() }
+        }
+
+        fun stopHealthMonitor() {
+            healthStop = true
+            healthThread?.interrupt()
+            healthThread = null
         }
 
         private fun buildJsonRpc(url: String, method: String, params: JSONObject, id: Int): Request {
@@ -353,213 +249,6 @@ class ApkMcpBridge(private val settings: SettingsStore) {
         }
     }
 
-    /**
-     * Minimal MCP-over-SSE client.
-     *
-     * Assumes the remote exposes:
-     *  - GET /sse  -> EventSource stream
-     *  - POST /messages?session_id=... -> JSON-RPC requests
-     */
-    private class SseClient(private val baseUrl: String, private val token: String) {
-        private val client: OkHttpClient = OkHttpClient.Builder()
-            .connectTimeout(8, TimeUnit.SECONDS)
-            .readTimeout(0, TimeUnit.SECONDS)
-            .build()
-
-        @Volatile private var messageEndpoint: String? = null
-
-        fun listTools(timeoutMs: Int): List<BridgeConnection.ToolDef> {
-            val sseUrl = baseUrl.replace("/mcp", "/sse").replace(Regex("/+$"), "/sse")
-            val latch = CountDownLatch(1)
-            val resultHolder = Array<JSONObject?>(null)
-            val errorHolder = Array<String?>(null)
-
-            val request = Request.Builder().url(sseUrl).get().build()
-            val eventSource = client.newSseClient(request, object : EventSourceListener() {
-                override fun onOpen(eventSource: EventSource, response: okhttp3.Response) {
-                    AppLog.d("sse connected: $sseUrl")
-                }
-
-                override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
-                    if (type == null) return
-                    if (type == "endpoint") {
-                        messageEndpoint = data.trim()
-                        AppLog.d("sse endpoint: $messageEndpoint")
-                    } else if (type == "message") {
-                        try {
-                            val root = JSONObject(data)
-                            val result = root.optJSONObject("result")
-                            if (result != null && result.has("tools")) {
-                                resultHolder[0] = result
-                                latch.countDown()
-                            }
-                        } catch (_: Exception) {}
-                    }
-                }
-
-                override fun onFailure(eventSource: EventSource, t: Throwable, response: okhttp3.Response?) {
-                    errorHolder[0] = t.message ?: t.javaClass.simpleName
-                    latch.countDown()
-                }
-
-                override fun onClosed(eventSource: EventSource) {
-                    latch.countDown()
-                }
-            })
-
-            if (!latch.await(timeoutMs.toLong(), TimeUnit.MILLISECONDS)) {
-                eventSource.cancel()
-                throw java.util.concurrent.TimeoutException("SSE connect timeout")
-            }
-            val error = errorHolder[0]
-            if (error != null) {
-                eventSource.cancel()
-                throw IOException("SSE connection failed: $error")
-            }
-
-            val endpoint = messageEndpoint ?: throw IOException("No SSE endpoint received")
-            val absoluteEndpoint = if (endpoint.startsWith("http")) endpoint else baseUrl + endpoint
-            val reqBody = JSONObject()
-                .put("jsonrpc", "2.0")
-                .put("id", AtomicInteger(1000).incrementAndGet())
-                .put("method", "tools/list")
-                .put("params", JSONObject())
-                .toString()
-
-            val postReq = Request.Builder()
-                .url(absoluteEndpoint)
-                .post(reqBody.toRequestBody("application/json".toMediaType()))
-                .build()
-
-            val resp = client.newCall(postReq).execute()
-            val body = resp.body?.string().orEmpty()
-            eventSource.cancel()
-            if (!resp.isSuccessful) throw IllegalStateException("HTTP ${resp.code}")
-            return parseTools(body)
-        }
-
-        fun ping(timeoutMs: Int) {
-            val sseUrl = baseUrl.replace("/mcp", "/sse").replace(Regex("/+$"), "/sse")
-            val latch = CountDownLatch(1)
-            val errorHolder = Array<String?>(null)
-
-            val request = Request.Builder().url(sseUrl).get().build()
-            val eventSource = client.newSseClient(request, object : EventSourceListener() {
-                override fun onOpen(eventSource: EventSource, response: okhttp3.Response) {}
-                override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
-                    if (type == "endpoint") {
-                        messageEndpoint = data.trim()
-                        latch.countDown()
-                    }
-                }
-                override fun onFailure(eventSource: EventSource, t: Throwable, response: okhttp3.Response?) {
-                    errorHolder[0] = t.message ?: t.javaClass.simpleName
-                    latch.countDown()
-                }
-                override fun onClosed(eventSource: EventSource) {
-                    latch.countDown()
-                }
-            })
-
-            if (!latch.await(timeoutMs.toLong(), TimeUnit.MILLISECONDS)) {
-                eventSource.cancel()
-                throw java.util.concurrent.TimeoutException("SSE ping timeout")
-            }
-            val error = errorHolder[0]
-            if (error != null) {
-                eventSource.cancel()
-                throw IOException("SSE ping failed: $error")
-            }
-            eventSource.cancel()
-        }
-
-        fun callTool(method: String, params: JSONObject, timeoutMs: Int): String {
-            val sseUrl = baseUrl.replace("/mcp", "/sse").replace(Regex("/+$"), "/sse")
-            val latch = CountDownLatch(1)
-            val resultHolder = Array<String?>(null)
-            val errorHolder = Array<String?>(null)
-
-            val request = Request.Builder().url(sseUrl).get().build()
-            val eventSource = client.newSseClient(request, object : EventSourceListener() {
-                override fun onOpen(eventSource: EventSource, response: okhttp3.Response) {}
-                override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
-                    if (type == "endpoint") {
-                        messageEndpoint = data.trim()
-                        val absoluteEndpoint = if (data.trim().startsWith("http")) data.trim() else baseUrl + data.trim()
-                        val reqId = AtomicInteger(1000).incrementAndGet()
-                        val body = JSONObject()
-                            .put("jsonrpc", "2.0")
-                            .put("id", reqId)
-                            .put("method", method)
-                            .put("params", params)
-                            .toString()
-                        val postReq = Request.Builder()
-                            .url(absoluteEndpoint)
-                            .post(body.toRequestBody("application/json".toMediaType()))
-                            .build()
-                        client.newCall(postReq).enqueue(object : okhttp3.Callback {
-                            override fun onFailure(call: okhttp3.Call, e: java.io.IOException) {
-                                errorHolder[0] = e.message
-                                latch.countDown()
-                            }
-                            override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
-                                val b = response.body?.string().orEmpty()
-                                if (!response.isSuccessful) {
-                                    errorHolder[0] = "HTTP ${response.code}: $b"
-                                } else {
-                                    resultHolder[0] = b
-                                }
-                                latch.countDown()
-                            }
-                        })
-                    } else if (type == "message") {
-                        resultHolder[0] = data
-                        latch.countDown()
-                    }
-                }
-                override fun onFailure(eventSource: EventSource, t: Throwable, response: okhttp3.Response?) {
-                    errorHolder[0] = t.message ?: t.javaClass.simpleName
-                    latch.countDown()
-                }
-                override fun onClosed(eventSource: EventSource) {
-                    latch.countDown()
-                }
-            })
-
-            if (!latch.await(timeoutMs.toLong(), TimeUnit.MILLISECONDS)) {
-                eventSource.cancel()
-                throw java.util.concurrent.TimeoutException("SSE call timeout")
-            }
-            val error = errorHolder[0]
-            if (error != null) {
-                eventSource.cancel()
-                throw IOException("SSE call failed: $error")
-            }
-            eventSource.cancel()
-            return resultHolder[0] ?: throw IOException("Empty SSE response")
-        }
-
-        private fun parseTools(body: String): List<BridgeConnection.ToolDef> {
-            val root = JSONObject(body)
-            val result = root.opt("result") as? JSONObject ?: return emptyList()
-            val tools = result.optJSONArray("tools") ?: return emptyList()
-            val out = ArrayList<BridgeConnection.ToolDef>(tools.length())
-            for (i in 0 until tools.length()) {
-                val t = tools.getJSONObject(i)
-                out.add(
-                    BridgeConnection.ToolDef(
-                        name = t.optString("name"),
-                        title = t.optString("title").takeIf { it.isNotBlank() },
-                        description = t.optString("description").takeIf { it.isNotBlank() },
-                        inputSchema = t.optJSONObject("inputSchema"),
-                        outputSchema = t.optJSONObject("outputSchema"),
-                    )
-                )
-            }
-            return out
-        }
-    }
-
     private val connections = CopyOnWriteArrayList<BridgeConnection>()
 
     init {
@@ -590,16 +279,16 @@ class ApkMcpBridge(private val settings: SettingsStore) {
         val existingUrls = connections.map { it.url }.toSet()
         for (config in configs) {
             if (config.url !in existingUrls) {
-                connections.add(BridgeConnection(config.url, config.token, config.transport))
+                connections.add(BridgeConnection(config.url, config.token))
             }
         }
     }
 
     /** Ensure a connection exists for the given URL, adding it if new. */
-    private fun ensureConnection(url: String, token: String = "", transport: String = "auto"): BridgeConnection {
+    private fun ensureConnection(url: String, token: String = ""): BridgeConnection {
         syncConnectionsFromSettings()
         return connections.firstOrNull { it.url == url } ?: run {
-            val conn = BridgeConnection(url, token, transport)
+            val conn = BridgeConnection(url, token)
             connections.add(conn)
             conn
         }
@@ -625,15 +314,14 @@ class ApkMcpBridge(private val settings: SettingsStore) {
             )
             for (url in candidates) {
                 try {
-                    val transport = if (p == NP_PORT) "sse" else "auto"
-                    val conn = BridgeConnection(url, "", transport)
+                    val conn = BridgeConnection(url, "")
                     val st = conn.probe()
                     if (st.online) {
                         connections.add(conn)
                         // Save to settings
                         val configs = settings.apkMcpConfigs.toMutableList()
                         if (configs.none { it.url == url }) {
-                            configs.add(SettingsStore.BridgeConfig(url, "", transport))
+                            configs.add(SettingsStore.BridgeConfig(url, ""))
                             settings.apkMcpConfigs = configs
                         }
                         if (firstState == null) firstState = st
@@ -676,14 +364,13 @@ class ApkMcpBridge(private val settings: SettingsStore) {
      */
     @Synchronized
     fun probeUrl(url: String, token: String = ""): State {
-        val transport = if (url.contains(":8788") || url.contains("/np")) "sse" else "auto"
-        val conn = ensureConnection(url, token, transport)
+        val conn = ensureConnection(url, token)
         val st = conn.probe()
         // Always save to settings so the bridge appears in the UI list
         // even when it is currently offline (user can retry later).
         val configs = settings.apkMcpConfigs.toMutableList()
         if (configs.none { it.url == url }) {
-            configs.add(SettingsStore.BridgeConfig(url, token, transport))
+            configs.add(SettingsStore.BridgeConfig(url, token))
             settings.apkMcpConfigs = configs
         }
         return st
@@ -813,7 +500,6 @@ class ApkMcpBridge(private val settings: SettingsStore) {
                 .put("probeFailures", st.probeFailures)
                 .put("lossRate", st.lossRate())
                 .put("tools", JSONArray().apply { st.tools.forEach { put(it.name) } })
-                .put("transport", config.transport)
             )
         }
         val firstOnline = connections.firstOrNull { it.state.online }
@@ -848,7 +534,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
         const val MT_PREFIX = "mt_apk_"
         const val NP_PREFIX = "np_"
         val KNOWN_PREFIXES = listOf(MT_PREFIX, NP_PREFIX)
-        val connIdCounter = AtomicInteger(1000)
+        private val connIdCounter = AtomicInteger(1000)
 
         fun prefixLabel(prefix: String?): String = when (prefix) {
             MT_PREFIX -> "MT Manager"

--- a/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
@@ -7,7 +7,10 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -54,7 +57,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
     /**
      * Internal representation of a single bridge connection.
      */
-    private class BridgeConnection(val url: String, val token: String) {
+    private class BridgeConnection(val url: String, val token: String, val transport: String = "auto") {
         @Volatile var state: State = State(url = url)
         private val client: OkHttpClient by lazy {
             OkHttpClient.Builder()
@@ -66,21 +69,29 @@ class ApkMcpBridge(private val settings: SettingsStore) {
         @Volatile private var healthThread: Thread? = null
         @Volatile private var healthStop = false
 
+        private fun shouldUseSse(): Boolean {
+            return when (transport) {
+                "sse" -> true
+                "http" -> false
+                "auto" -> url.contains(":8788") || url.contains("/np") || state.toolPrefix == NP_PREFIX
+                else -> false
+            }
+        }
+
         @Synchronized
         fun probe(timeoutMs: Int = 8000): State {
-            try {
-                val req = buildJsonRpc(url, "tools/list", JSONObject(), id = connIdCounter.incrementAndGet())
+            return try {
+                val sseClient = SseClient(url, token)
                 val start = System.nanoTime()
-                val resp = post(req)
+                val tools = sseClient.listTools(timeoutMs)
                 val latencyMs = (System.nanoTime() - start) / 1_000_000
-                val parsed = parseTools(resp)
-                val prefix = detectPrefix(parsed)
+                val prefix = detectPrefix(tools)
                 val prev = state
                 val s = State(
                     url = url,
                     online = true,
                     lastError = "",
-                    tools = parsed,
+                    tools = tools,
                     toolPrefix = prefix ?: prev.toolPrefix,
                     lastCheckedAt = System.currentTimeMillis(),
                     lastLatencyMs = latencyMs,
@@ -91,25 +102,25 @@ class ApkMcpBridge(private val settings: SettingsStore) {
                 )
                 state = s
                 val label = prefixLabel(prefix)
-                AppLog.i("apk-mcp bridge online: ${parsed.size} tools from $url ($label, ${latencyMs}ms)")
-                return s
+                AppLog.i("apk-mcp bridge online (sse): ${tools.size} tools from $url ($label, ${latencyMs}ms)")
+                s
             } catch (e: Exception) {
                 val prev = state
                 val s = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName,
                     probes = prev.probes + 1, probeFailures = prev.probeFailures + 1,
                     totalLatencyMs = prev.totalLatencyMs, maxLatencyMs = prev.maxLatencyMs)
                 state = s
-                AppLog.w("apk-mcp probe failed: $url ${e.message}")
-                return s
+                AppLog.w("apk-mcp probe failed (sse): $url ${e.message}")
+                s
             }
         }
 
         @Synchronized
         fun ping(): State {
             return try {
-                val req = buildJsonRpc(url, "initialize", JSONObject().put("client", "somcp-ping"), id = connIdCounter.incrementAndGet())
+                val sseClient = SseClient(url, token)
                 val start = System.nanoTime()
-                post(req)
+                sseClient.ping(timeoutMs = 8000)
                 val latencyMs = (System.nanoTime() - start) / 1_000_000
                 val prev = state
                 val s = if (!prev.online) {
@@ -140,8 +151,8 @@ class ApkMcpBridge(private val settings: SettingsStore) {
             }
             val params = JSONObject().put("name", name).put("arguments", arguments)
             return try {
-                val req = buildJsonRpc(url, "tools/call", params, id = connIdCounter.incrementAndGet())
-                val resp = post(req)
+                val sseClient = SseClient(url, token)
+                val resp = sseClient.callTool("tools/call", params, timeoutMs = 20000)
                 parseToolResult(resp)
             } catch (e: Exception) {
                 errorResult(name, "forward failed: ${e.message}")
@@ -150,6 +161,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
 
         fun startHealthMonitor(intervalMs: Long = 30_000) {
             stopHealthMonitor()
+            val sseClient = SseClient(url, token)
             healthStop = false
             healthThread = Thread({
                 while (!healthStop && !Thread.currentThread().isInterrupted) {
@@ -158,24 +170,24 @@ class ApkMcpBridge(private val settings: SettingsStore) {
                     } catch (_: InterruptedException) { break }
                     if (healthStop) break
                     try {
-                        val req = buildJsonRpc(url, "tools/list", JSONObject(), id = connIdCounter.incrementAndGet())
-                        val resp = post(req)
-                        val parsed = parseTools(resp)
-                        val prefix = detectPrefix(parsed)
+                        val start = System.nanoTime()
+                        val tools = sseClient.listTools(timeoutMs = 8000)
+                        val latencyMs = (System.nanoTime() - start) / 1_000_000
+                        val prefix = detectPrefix(tools)
                         if (prefix != null) {
                             val cur = state
-                            state = State(url = url, online = true, lastError = "", tools = parsed, toolPrefix = prefix, lastCheckedAt = System.currentTimeMillis())
-                            if (!cur.online) AppLog.i("apk-mcp health: $url back online (${parsed.size} tools, prefix=$prefix)")
+                            state = State(url = url, online = true, lastError = "", tools = tools, toolPrefix = prefix, lastCheckedAt = System.currentTimeMillis(), lastLatencyMs = latencyMs)
+                            if (!cur.online) AppLog.i("apk-mcp health (sse): $url back online (${tools.size} tools, prefix=$prefix)")
                         }
                     } catch (e: Exception) {
                         val cur = state
                         if (cur.online) {
                             state = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName, tools = emptyList(), lastCheckedAt = System.currentTimeMillis())
-                            AppLog.w("apk-mcp health: $url marked offline (${e.message})")
+                            AppLog.w("apk-mcp health (sse): $url marked offline (${e.message})")
                         }
                     }
                 }
-            }, "apk-mcp-health-$url").apply { isDaemon = true; start() }
+            }, "apk-mcp-health-sse-$url").apply { isDaemon = true; start() }
         }
 
         fun stopHealthMonitor() {
@@ -249,6 +261,218 @@ class ApkMcpBridge(private val settings: SettingsStore) {
         }
     }
 
+    /**
+     * Minimal MCP-over-SSE client.
+     *
+     * Assumes the remote exposes:
+     *  - GET /sse  -> EventSource stream
+     *  - POST /messages?session_id=... -> JSON-RPC requests
+     */
+    private class SseClient(private val baseUrl: String, private val token: String) {
+        private val client: OkHttpClient = OkHttpClient.Builder()
+            .connectTimeout(8, TimeUnit.SECONDS)
+            .readTimeout(0, TimeUnit.SECONDS)
+            .build()
+
+        @Volatile private var sessionId: String? = null
+        @Volatile private var messageEndpoint: String? = null
+
+        fun listTools(timeoutMs: Int): List<BridgeConnection.ToolDef> {
+            val sseUrl = baseUrl.replace("/mcp", "/sse").replace(Regex("/+$"), "/sse")
+            val latch = CountDownLatch(1)
+            val resultHolder = Array<JSONObject?>(null)
+            val errorHolder = Array<String?>(null)
+
+            val request = Request.Builder().url(sseUrl).get().build()
+            val eventSource = client.newSseClient(request, object : EventSourceListener() {
+                override fun onOpen(eventSource: EventSource, response: okhttp3.Response) {
+                    AppLog.d("sse connected: $sseUrl")
+                }
+
+                override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
+                    when (type) {
+                        "endpoint" -> {
+                            messageEndpoint = data.trim()
+                            AppLog.d("sse endpoint: $messageEndpoint")
+                        }
+                        "message" -> {
+                            try {
+                                val root = JSONObject(data)
+                                val result = root.optJSONObject("result")
+                                if (result != null && result.has("tools")) {
+                                    resultHolder[0] = result
+                                    latch.countDown()
+                                }
+                            } catch (_: Exception) {}
+                        }
+                    }
+                }
+
+                override fun onFailure(eventSource: EventSource, t: Throwable, response: okhttp3.Response?) {
+                    errorHolder[0] = t.message ?: t.javaClass.simpleName
+                    latch.countDown()
+                }
+
+                override fun onClosed(eventSource: EventSource) {
+                    latch.countDown()
+                }
+            })
+
+            // Wait for endpoint event
+            if (!latch.await(timeoutMs.toLong(), TimeUnit.MILLISECONDS)) {
+                eventSource.cancel()
+                throw java.util.concurrent.TimeoutException("SSE connect timeout")
+            }
+            val error = errorHolder[0]
+            if (error != null) {
+                eventSource.cancel()
+                throw IOException("SSE connection failed: $error")
+            }
+
+            val endpoint = messageEndpoint ?: throw IOException("No SSE endpoint received")
+            val absoluteEndpoint = if (endpoint.startsWith("http")) endpoint else baseUrl + endpoint
+            val reqBody = JSONObject()
+                .put("jsonrpc", "2.0")
+                .put("id", AtomicInteger(1000).incrementAndGet())
+                .put("method", "tools/list")
+                .put("params", JSONObject())
+                .toString()
+
+            val postReq = Request.Builder()
+                .url(absoluteEndpoint)
+                .post(reqBody.toRequestBody("application/json".toMediaType()))
+                .build()
+
+            val resp = client.newCall(postReq).execute()
+            val body = resp.body?.string().orEmpty()
+            eventSource.cancel()
+            if (!resp.isSuccessful) throw IllegalStateException("HTTP ${resp.code}")
+            return parseTools(body)
+        }
+
+        fun ping(timeoutMs: Int) {
+            val sseUrl = baseUrl.replace("/mcp", "/sse").replace(Regex("/+$"), "/sse")
+            val latch = CountDownLatch(1)
+            val errorHolder = Array<String?>(null)
+
+            val request = Request.Builder().url(sseUrl).get().build()
+            val eventSource = client.newSseClient(request, object : EventSourceListener() {
+                override fun onOpen(eventSource: EventSource, response: okhttp3.Response) {}
+                override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
+                    if (type == "endpoint") {
+                        messageEndpoint = data.trim()
+                        latch.countDown()
+                    }
+                }
+                override fun onFailure(eventSource: EventSource, t: Throwable, response: okhttp3.Response?) {
+                    errorHolder[0] = t.message ?: t.javaClass.simpleName
+                    latch.countDown()
+                }
+                override fun onClosed(eventSource: EventSource) {
+                    latch.countDown()
+                }
+            })
+
+            if (!latch.await(timeoutMs.toLong(), TimeUnit.MILLISECONDS)) {
+                eventSource.cancel()
+                throw java.util.concurrent.TimeoutException("SSE ping timeout")
+            }
+            val error = errorHolder[0]
+            if (error != null) {
+                eventSource.cancel()
+                throw IOException("SSE ping failed: $error")
+            }
+            eventSource.cancel()
+        }
+
+        fun callTool(method: String, params: JSONObject, timeoutMs: Int): String {
+            val sseUrl = baseUrl.replace("/mcp", "/sse").replace(Regex("/+$"), "/sse")
+            val latch = CountDownLatch(1)
+            val resultHolder = Array<String?>(null)
+            val errorHolder = Array<String?>(null)
+
+            val request = Request.Builder().url(sseUrl).get().build()
+            val eventSource = client.newSseClient(request, object : EventSourceListener() {
+                override fun onOpen(eventSource: EventSource, response: okhttp3.Response) {}
+                override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
+                    if (type == "endpoint") {
+                        messageEndpoint = data.trim()
+                        val absoluteEndpoint = if (data.trim().startsWith("http")) data.trim() else baseUrl + data.trim()
+                        val reqId = AtomicInteger(1000).incrementAndGet()
+                        val body = JSONObject()
+                            .put("jsonrpc", "2.0")
+                            .put("id", reqId)
+                            .put("method", method)
+                            .put("params", params)
+                            .toString()
+                        val postReq = Request.Builder()
+                            .url(absoluteEndpoint)
+                            .post(body.toRequestBody("application/json".toMediaType()))
+                            .build()
+                        client.newCall(postReq).enqueue(object : okhttp3.Callback {
+                            override fun onFailure(call: okhttp3.Call, e: java.io.IOException) {
+                                errorHolder[0] = e.message
+                                latch.countDown()
+                            }
+                            override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
+                                val b = response.body?.string().orEmpty()
+                                if (!response.isSuccessful) {
+                                    errorHolder[0] = "HTTP ${response.code}: $b"
+                                } else {
+                                    resultHolder[0] = b
+                                }
+                                latch.countDown()
+                            }
+                        })
+                    } else if (type == "message") {
+                        // Some servers push result via SSE instead of HTTP response
+                        resultHolder[0] = data
+                        latch.countDown()
+                    }
+                }
+                override fun onFailure(eventSource: EventSource, t: Throwable, response: okhttp3.Response?) {
+                    errorHolder[0] = t.message ?: t.javaClass.simpleName
+                    latch.countDown()
+                }
+                override fun onClosed(eventSource: EventSource) {
+                    latch.countDown()
+                }
+            })
+
+            if (!latch.await(timeoutMs.toLong(), TimeUnit.MILLISECONDS)) {
+                eventSource.cancel()
+                throw java.util.concurrent.TimeoutException("SSE call timeout")
+            }
+            val error = errorHolder[0]
+            if (error != null) {
+                eventSource.cancel()
+                throw IOException("SSE call failed: $error")
+            }
+            eventSource.cancel()
+            return resultHolder[0] ?: throw IOException("Empty SSE response")
+        }
+
+        private fun parseTools(body: String): List<BridgeConnection.ToolDef> {
+            val root = JSONObject(body)
+            val result = root.opt("result") as? JSONObject ?: return emptyList()
+            val tools = result.optJSONArray("tools") ?: return emptyList()
+            val out = ArrayList<BridgeConnection.ToolDef>(tools.length())
+            for (i in 0 until tools.length()) {
+                val t = tools.getJSONObject(i)
+                out.add(
+                    BridgeConnection.ToolDef(
+                        name = t.optString("name"),
+                        title = t.optString("title").takeIf { it.isNotBlank() },
+                        description = t.optString("description").takeIf { it.isNotBlank() },
+                        inputSchema = t.optJSONObject("inputSchema"),
+                        outputSchema = t.optJSONObject("outputSchema"),
+                    )
+                )
+            }
+            return out
+        }
+    }
+
     private val connections = CopyOnWriteArrayList<BridgeConnection>()
 
     init {
@@ -279,16 +503,16 @@ class ApkMcpBridge(private val settings: SettingsStore) {
         val existingUrls = connections.map { it.url }.toSet()
         for (config in configs) {
             if (config.url !in existingUrls) {
-                connections.add(BridgeConnection(config.url, config.token))
+                connections.add(BridgeConnection(config.url, config.token, config.transport))
             }
         }
     }
 
     /** Ensure a connection exists for the given URL, adding it if new. */
-    private fun ensureConnection(url: String, token: String = ""): BridgeConnection {
+    private fun ensureConnection(url: String, token: String = "", transport: String = "auto"): BridgeConnection {
         syncConnectionsFromSettings()
         return connections.firstOrNull { it.url == url } ?: run {
-            val conn = BridgeConnection(url, token)
+            val conn = BridgeConnection(url, token, transport)
             connections.add(conn)
             conn
         }
@@ -314,14 +538,15 @@ class ApkMcpBridge(private val settings: SettingsStore) {
             )
             for (url in candidates) {
                 try {
-                    val conn = BridgeConnection(url, "")
+                    val transport = if (p == NP_PORT) "sse" else "auto"
+                    val conn = BridgeConnection(url, "", transport)
                     val st = conn.probe()
                     if (st.online) {
                         connections.add(conn)
                         // Save to settings
                         val configs = settings.apkMcpConfigs.toMutableList()
                         if (configs.none { it.url == url }) {
-                            configs.add(SettingsStore.BridgeConfig(url, ""))
+                            configs.add(SettingsStore.BridgeConfig(url, "", transport))
                             settings.apkMcpConfigs = configs
                         }
                         if (firstState == null) firstState = st
@@ -364,13 +589,14 @@ class ApkMcpBridge(private val settings: SettingsStore) {
      */
     @Synchronized
     fun probeUrl(url: String, token: String = ""): State {
-        val conn = ensureConnection(url, token)
+        val transport = if (url.contains(":8788") || url.contains("/np")) "sse" else "auto"
+        val conn = ensureConnection(url, token, transport)
         val st = conn.probe()
         // Always save to settings so the bridge appears in the UI list
         // even when it is currently offline (user can retry later).
         val configs = settings.apkMcpConfigs.toMutableList()
         if (configs.none { it.url == url }) {
-            configs.add(SettingsStore.BridgeConfig(url, token))
+            configs.add(SettingsStore.BridgeConfig(url, token, transport))
             settings.apkMcpConfigs = configs
         }
         return st
@@ -500,6 +726,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
                 .put("probeFailures", st.probeFailures)
                 .put("lossRate", st.lossRate())
                 .put("tools", JSONArray().apply { st.tools.forEach { put(it.name) } })
+                .put("transport", config.transport)
             )
         }
         val firstOnline = connections.firstOrNull { it.state.online }

--- a/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
@@ -80,6 +80,151 @@ class ApkMcpBridge(private val settings: SettingsStore) {
 
         @Synchronized
         fun probe(timeoutMs: Int = 8000): State {
+            return if (shouldUseSse()) {
+                probeSse(timeoutMs)
+            } else {
+                probeHttp(timeoutMs)
+            }
+        }
+
+        @Synchronized
+        fun ping(): State {
+            return if (shouldUseSse()) {
+                pingSse()
+            } else {
+                pingHttp()
+            }
+        }
+
+        fun callTool(name: String, arguments: JSONObject): JSONObject {
+            val st = state
+            if (!st.online || st.url.isBlank()) {
+                return errorResult(name, "APK MCP $url is offline or not configured")
+            }
+            val params = JSONObject().put("name", name).put("arguments", arguments)
+            return try {
+                if (shouldUseSse()) {
+                    val sseClient = SseClient(url, token)
+                    val resp = sseClient.callTool("tools/call", params, timeoutMs = 20000)
+                    parseToolResult(resp)
+                } else {
+                    val req = buildJsonRpc(url, "tools/call", params, id = connIdCounter.incrementAndGet())
+                    val resp = post(req)
+                    parseToolResult(resp)
+                }
+            } catch (e: Exception) {
+                errorResult(name, "forward failed: ${e.message}")
+            }
+        }
+
+        fun startHealthMonitor(intervalMs: Long = 30_000) {
+            stopHealthMonitor()
+            healthStop = false
+            healthThread = Thread({
+                while (!healthStop && !Thread.currentThread().isInterrupted) {
+                    try {
+                        Thread.sleep(intervalMs)
+                    } catch (_: InterruptedException) { break }
+                    if (healthStop) break
+                    try {
+                        val start = System.nanoTime()
+                        val tools = if (shouldUseSse()) {
+                            SseClient(url, token).listTools(timeoutMs = 8000)
+                        } else {
+                            val req = buildJsonRpc(url, "tools/list", JSONObject(), id = connIdCounter.incrementAndGet())
+                            val resp = post(req)
+                            parseTools(resp)
+                        }
+                        val latencyMs = (System.nanoTime() - start) / 1_000_000
+                        val prefix = detectPrefix(tools)
+                        if (prefix != null) {
+                            val cur = state
+                            state = State(url = url, online = true, lastError = "", tools = tools, toolPrefix = prefix, lastCheckedAt = System.currentTimeMillis(), lastLatencyMs = latencyMs)
+                            if (!cur.online) AppLog.i("apk-mcp health: $url back online (${tools.size} tools, prefix=$prefix)")
+                        }
+                    } catch (e: Exception) {
+                        val cur = state
+                        if (cur.online) {
+                            state = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName, tools = emptyList(), lastCheckedAt = System.currentTimeMillis())
+                            AppLog.w("apk-mcp health: $url marked offline (${e.message})")
+                        }
+                    }
+                }
+            }, "apk-mcp-health-$url").apply { isDaemon = true; start() }
+        }
+
+        fun stopHealthMonitor() {
+            healthStop = true
+            healthThread?.interrupt()
+            healthThread = null
+        }
+
+        private fun probeHttp(timeoutMs: Int): State {
+            return try {
+                val req = buildJsonRpc(url, "tools/list", JSONObject(), id = connIdCounter.incrementAndGet())
+                val start = System.nanoTime()
+                val resp = post(req)
+                val latencyMs = (System.nanoTime() - start) / 1_000_000
+                val parsed = parseTools(resp)
+                val prefix = detectPrefix(parsed)
+                val prev = state
+                val s = State(
+                    url = url,
+                    online = true,
+                    lastError = "",
+                    tools = parsed,
+                    toolPrefix = prefix ?: prev.toolPrefix,
+                    lastCheckedAt = System.currentTimeMillis(),
+                    lastLatencyMs = latencyMs,
+                    probes = prev.probes + 1,
+                    probeFailures = prev.probeFailures,
+                    totalLatencyMs = prev.totalLatencyMs + latencyMs,
+                    maxLatencyMs = maxOf(prev.maxLatencyMs, latencyMs),
+                )
+                state = s
+                val label = prefixLabel(prefix)
+                AppLog.i("apk-mcp bridge online: ${parsed.size} tools from $url ($label, ${latencyMs}ms)")
+                return s
+            } catch (e: Exception) {
+                val prev = state
+                val s = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName,
+                    probes = prev.probes + 1, probeFailures = prev.probeFailures + 1,
+                    totalLatencyMs = prev.totalLatencyMs, maxLatencyMs = prev.maxLatencyMs)
+                state = s
+                AppLog.w("apk-mcp probe failed: $url ${e.message}")
+                return s
+            }
+        }
+
+        private fun pingHttp(): State {
+            return try {
+                val req = buildJsonRpc(url, "initialize", JSONObject().put("client", "somcp-ping"), id = connIdCounter.incrementAndGet())
+                val start = System.nanoTime()
+                post(req)
+                val latencyMs = (System.nanoTime() - start) / 1_000_000
+                val prev = state
+                val s = if (!prev.online) {
+                    prev.copy(lastLatencyMs = latencyMs, lastCheckedAt = System.currentTimeMillis(),
+                        probes = prev.probes + 1, lastError = "", online = false, tools = prev.tools)
+                } else {
+                    State(url = url, online = true, lastError = "", tools = prev.tools,
+                        lastCheckedAt = System.currentTimeMillis(), lastLatencyMs = latencyMs,
+                        probes = prev.probes + 1, probeFailures = prev.probeFailures,
+                        totalLatencyMs = prev.totalLatencyMs + latencyMs, maxLatencyMs = maxOf(prev.maxLatencyMs, latencyMs))
+                }
+                state = s
+                s
+            } catch (e: Exception) {
+                val prev = state
+                val s = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName,
+                    probes = prev.probes + 1, probeFailures = prev.probeFailures + 1,
+                    totalLatencyMs = prev.totalLatencyMs, maxLatencyMs = prev.maxLatencyMs)
+                state = s
+                s
+            }
+        }
+
+        private fun probeSse(timeoutMs: Int): State {
             return try {
                 val sseClient = SseClient(url, token)
                 val start = System.nanoTime()
@@ -115,8 +260,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
             }
         }
 
-        @Synchronized
-        fun ping(): State {
+        private fun pingSse(): State {
             return try {
                 val sseClient = SseClient(url, token)
                 val start = System.nanoTime()
@@ -142,58 +286,6 @@ class ApkMcpBridge(private val settings: SettingsStore) {
                 state = s
                 s
             }
-        }
-
-        fun callTool(name: String, arguments: JSONObject): JSONObject {
-            val st = state
-            if (!st.online || st.url.isBlank()) {
-                return errorResult(name, "APK MCP $url is offline or not configured")
-            }
-            val params = JSONObject().put("name", name).put("arguments", arguments)
-            return try {
-                val sseClient = SseClient(url, token)
-                val resp = sseClient.callTool("tools/call", params, timeoutMs = 20000)
-                parseToolResult(resp)
-            } catch (e: Exception) {
-                errorResult(name, "forward failed: ${e.message}")
-            }
-        }
-
-        fun startHealthMonitor(intervalMs: Long = 30_000) {
-            stopHealthMonitor()
-            val sseClient = SseClient(url, token)
-            healthStop = false
-            healthThread = Thread({
-                while (!healthStop && !Thread.currentThread().isInterrupted) {
-                    try {
-                        Thread.sleep(intervalMs)
-                    } catch (_: InterruptedException) { break }
-                    if (healthStop) break
-                    try {
-                        val start = System.nanoTime()
-                        val tools = sseClient.listTools(timeoutMs = 8000)
-                        val latencyMs = (System.nanoTime() - start) / 1_000_000
-                        val prefix = detectPrefix(tools)
-                        if (prefix != null) {
-                            val cur = state
-                            state = State(url = url, online = true, lastError = "", tools = tools, toolPrefix = prefix, lastCheckedAt = System.currentTimeMillis(), lastLatencyMs = latencyMs)
-                            if (!cur.online) AppLog.i("apk-mcp health (sse): $url back online (${tools.size} tools, prefix=$prefix)")
-                        }
-                    } catch (e: Exception) {
-                        val cur = state
-                        if (cur.online) {
-                            state = State(url = url, online = false, lastError = e.message ?: e.javaClass.simpleName, tools = emptyList(), lastCheckedAt = System.currentTimeMillis())
-                            AppLog.w("apk-mcp health (sse): $url marked offline (${e.message})")
-                        }
-                    }
-                }
-            }, "apk-mcp-health-sse-$url").apply { isDaemon = true; start() }
-        }
-
-        fun stopHealthMonitor() {
-            healthStop = true
-            healthThread?.interrupt()
-            healthThread = null
         }
 
         private fun buildJsonRpc(url: String, method: String, params: JSONObject, id: Int): Request {
@@ -274,7 +366,6 @@ class ApkMcpBridge(private val settings: SettingsStore) {
             .readTimeout(0, TimeUnit.SECONDS)
             .build()
 
-        @Volatile private var sessionId: String? = null
         @Volatile private var messageEndpoint: String? = null
 
         fun listTools(timeoutMs: Int): List<BridgeConnection.ToolDef> {
@@ -290,21 +381,19 @@ class ApkMcpBridge(private val settings: SettingsStore) {
                 }
 
                 override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
-                    when (type) {
-                        "endpoint" -> {
-                            messageEndpoint = data.trim()
-                            AppLog.d("sse endpoint: $messageEndpoint")
-                        }
-                        "message" -> {
-                            try {
-                                val root = JSONObject(data)
-                                val result = root.optJSONObject("result")
-                                if (result != null && result.has("tools")) {
-                                    resultHolder[0] = result
-                                    latch.countDown()
-                                }
-                            } catch (_: Exception) {}
-                        }
+                    if (type == null) return
+                    if (type == "endpoint") {
+                        messageEndpoint = data.trim()
+                        AppLog.d("sse endpoint: $messageEndpoint")
+                    } else if (type == "message") {
+                        try {
+                            val root = JSONObject(data)
+                            val result = root.optJSONObject("result")
+                            if (result != null && result.has("tools")) {
+                                resultHolder[0] = result
+                                latch.countDown()
+                            }
+                        } catch (_: Exception) {}
                     }
                 }
 
@@ -318,7 +407,6 @@ class ApkMcpBridge(private val settings: SettingsStore) {
                 }
             })
 
-            // Wait for endpoint event
             if (!latch.await(timeoutMs.toLong(), TimeUnit.MILLISECONDS)) {
                 eventSource.cancel()
                 throw java.util.concurrent.TimeoutException("SSE connect timeout")
@@ -425,7 +513,6 @@ class ApkMcpBridge(private val settings: SettingsStore) {
                             }
                         })
                     } else if (type == "message") {
-                        // Some servers push result via SSE instead of HTTP response
                         resultHolder[0] = data
                         latch.countDown()
                     }

--- a/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/ApkMcpBridge.kt
@@ -108,7 +108,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
                     val resp = sseClient.callTool("tools/call", params, timeoutMs = 20000)
                     parseToolResult(resp)
                 } else {
-                    val req = buildJsonRpc(url, "tools/call", params, id = connIdCounter.incrementAndGet())
+                    val req = buildJsonRpc(url, "tools/call", params, id = ApkMcpBridge.connIdCounter.incrementAndGet())
                     val resp = post(req)
                     parseToolResult(resp)
                 }
@@ -131,7 +131,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
                         val tools = if (shouldUseSse()) {
                             SseClient(url, token).listTools(timeoutMs = 8000)
                         } else {
-                            val req = buildJsonRpc(url, "tools/list", JSONObject(), id = connIdCounter.incrementAndGet())
+                            val req = buildJsonRpc(url, "tools/list", JSONObject(), id = ApkMcpBridge.connIdCounter.incrementAndGet())
                             val resp = post(req)
                             parseTools(resp)
                         }
@@ -161,7 +161,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
 
         private fun probeHttp(timeoutMs: Int): State {
             return try {
-                val req = buildJsonRpc(url, "tools/list", JSONObject(), id = connIdCounter.incrementAndGet())
+                val req = buildJsonRpc(url, "tools/list", JSONObject(), id = ApkMcpBridge.connIdCounter.incrementAndGet())
                 val start = System.nanoTime()
                 val resp = post(req)
                 val latencyMs = (System.nanoTime() - start) / 1_000_000
@@ -198,7 +198,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
 
         private fun pingHttp(): State {
             return try {
-                val req = buildJsonRpc(url, "initialize", JSONObject().put("client", "somcp-ping"), id = connIdCounter.incrementAndGet())
+                val req = buildJsonRpc(url, "initialize", JSONObject().put("client", "somcp-ping"), id = ApkMcpBridge.connIdCounter.incrementAndGet())
                 val start = System.nanoTime()
                 post(req)
                 val latencyMs = (System.nanoTime() - start) / 1_000_000
@@ -296,7 +296,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
                 .put("params", params)
                 .toString()
             val builder = Request.Builder().url(url).post(body.toRequestBody("application/json".toMediaType()))
-            if (token.isNotBlank()) builder.safeHeader("Authorization", "Bearer $token")
+            if (token.isNotBlank()) builder.header("Authorization", "Bearer $token")
             return builder.build()
         }
 
@@ -848,7 +848,7 @@ class ApkMcpBridge(private val settings: SettingsStore) {
         const val MT_PREFIX = "mt_apk_"
         const val NP_PREFIX = "np_"
         val KNOWN_PREFIXES = listOf(MT_PREFIX, NP_PREFIX)
-        private val connIdCounter = AtomicInteger(1000)
+        val connIdCounter = AtomicInteger(1000)
 
         fun prefixLabel(prefix: String?): String = when (prefix) {
             MT_PREFIX -> "MT Manager"

--- a/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
@@ -22,8 +22,8 @@ class SettingsStore(context: Context) {
             val legacyUrl = prefs.getString("apkMcpUrl", "") ?: ""
             if (raw.isBlank() && legacyUrl.isBlank()) {
                 val arr = org.json.JSONArray()
-                arr.put(org.json.JSONObject().put("url", "http://127.0.0.1:8787/mcp").put("token", "").put("transport", "auto"))
-                arr.put(org.json.JSONObject().put("url", "http://127.0.0.1:8788/mcp").put("token", "").put("transport", "sse"))
+                arr.put(org.json.JSONObject().put("url", "http://127.0.0.1:8787/mcp").put("token", ""))
+                arr.put(org.json.JSONObject().put("url", "http://127.0.0.1:8788/mcp").put("token", ""))
                 prefs.edit().putString("apkMcpConfigs", arr.toString()).apply()
             }
             prefs.edit().putBoolean("apkDefaultBridgesAdded", true).apply()
@@ -502,9 +502,9 @@ class SettingsStore(context: Context) {
             apkMcpConfigs = configs
         }
 
-    data class BridgeConfig(val url: String, val token: String = "", val transport: String = "auto")
+    data class BridgeConfig(val url: String, val token: String = "")
 
-    /** Multiple bridge configurations as a JSON array of {"url","token","transport"} objects. */
+    /** Multiple bridge configurations as a JSON array of {"url","token"} objects. */
     var apkMcpConfigs: List<BridgeConfig>
         get() {
             val raw = prefs.getString("apkMcpConfigs", "") ?: ""
@@ -523,7 +523,6 @@ class SettingsStore(context: Context) {
                     BridgeConfig(
                         url = obj.optString("url", ""),
                         token = sanitizeCredential(obj.optString("token", "")),
-                        transport = obj.optString("transport", "auto").takeIf { it in setOf("auto", "http", "sse") } ?: "auto",
                     )
                 }.filter { it.url.isNotBlank() }
             } catch (_: Exception) { emptyList() }
@@ -533,8 +532,7 @@ class SettingsStore(context: Context) {
             value.forEach { config ->
                 arr.put(org.json.JSONObject()
                     .put("url", config.url.trim())
-                    .put("token", config.token)
-                    .put("transport", config.transport))
+                    .put("token", config.token))
             }
             prefs.edit().putString("apkMcpConfigs", arr.toString()).apply()
             // Keep legacy fields in sync for backward compatibility
@@ -702,7 +700,7 @@ class SettingsStore(context: Context) {
                 .put("apkMcpToken", mask(apkMcpToken))
                 .put("apkMcpConfigs", org.json.JSONArray().apply {
                     apkMcpConfigs.forEach { c ->
-                        put(org.json.JSONObject().put("url", c.url).put("token", mask(c.token)).put("transport", c.transport))
+                        put(org.json.JSONObject().put("url", c.url).put("token", mask(c.token)))
                     }
                 })
                 .put("apkMcpAutoProbe", apkMcpAutoProbe)
@@ -840,8 +838,7 @@ class SettingsStore(context: Context) {
                         val url = obj.optString("url", "").trim()
                         if (url.isNotBlank()) {
                             val token = if (allowSecrets) obj.optString("token", "") else ""
-                            val transport = obj.optString("transport", "auto").takeIf { it in setOf("auto", "http", "sse") } ?: "auto"
-                            configs.add(BridgeConfig(url, token, transport))
+                            configs.add(BridgeConfig(url, token))
                         }
                     }
                     if (configs.isNotEmpty()) apkMcpConfigs = configs

--- a/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
@@ -22,8 +22,8 @@ class SettingsStore(context: Context) {
             val legacyUrl = prefs.getString("apkMcpUrl", "") ?: ""
             if (raw.isBlank() && legacyUrl.isBlank()) {
                 val arr = org.json.JSONArray()
-                arr.put(org.json.JSONObject().put("url", "http://127.0.0.1:8787/mcp").put("token", ""))
-                arr.put(org.json.JSONObject().put("url", "http://127.0.0.1:8788/mcp").put("token", ""))
+                arr.put(org.json.JSONObject().put("url", "http://127.0.0.1:8787/mcp").put("token", "").put("transport", "auto"))
+                arr.put(org.json.JSONObject().put("url", "http://127.0.0.1:8788/mcp").put("token", "").put("transport", "sse"))
                 prefs.edit().putString("apkMcpConfigs", arr.toString()).apply()
             }
             prefs.edit().putBoolean("apkDefaultBridgesAdded", true).apply()
@@ -502,9 +502,9 @@ class SettingsStore(context: Context) {
             apkMcpConfigs = configs
         }
 
-    data class BridgeConfig(val url: String, val token: String = "")
+    data class BridgeConfig(val url: String, val token: String = "", val transport: String = "auto")
 
-    /** Multiple bridge configurations as a JSON array of {"url","token"} objects. */
+    /** Multiple bridge configurations as a JSON array of {"url","token","transport"} objects. */
     var apkMcpConfigs: List<BridgeConfig>
         get() {
             val raw = prefs.getString("apkMcpConfigs", "") ?: ""
@@ -523,6 +523,7 @@ class SettingsStore(context: Context) {
                     BridgeConfig(
                         url = obj.optString("url", ""),
                         token = sanitizeCredential(obj.optString("token", "")),
+                        transport = obj.optString("transport", "auto").takeIf { it in setOf("auto", "http", "sse") } ?: "auto",
                     )
                 }.filter { it.url.isNotBlank() }
             } catch (_: Exception) { emptyList() }
@@ -532,7 +533,8 @@ class SettingsStore(context: Context) {
             value.forEach { config ->
                 arr.put(org.json.JSONObject()
                     .put("url", config.url.trim())
-                    .put("token", config.token))
+                    .put("token", config.token)
+                    .put("transport", config.transport))
             }
             prefs.edit().putString("apkMcpConfigs", arr.toString()).apply()
             // Keep legacy fields in sync for backward compatibility
@@ -700,7 +702,7 @@ class SettingsStore(context: Context) {
                 .put("apkMcpToken", mask(apkMcpToken))
                 .put("apkMcpConfigs", org.json.JSONArray().apply {
                     apkMcpConfigs.forEach { c ->
-                        put(org.json.JSONObject().put("url", c.url).put("token", mask(c.token)))
+                        put(org.json.JSONObject().put("url", c.url).put("token", mask(c.token)).put("transport", c.transport))
                     }
                 })
                 .put("apkMcpAutoProbe", apkMcpAutoProbe)
@@ -838,7 +840,8 @@ class SettingsStore(context: Context) {
                         val url = obj.optString("url", "").trim()
                         if (url.isNotBlank()) {
                             val token = if (allowSecrets) obj.optString("token", "") else ""
-                            configs.add(BridgeConfig(url, token))
+                            val transport = obj.optString("transport", "auto").takeIf { it in setOf("auto", "http", "sse") } ?: "auto"
+                            configs.add(BridgeConfig(url, token, transport))
                         }
                     }
                     if (configs.isNotEmpty()) apkMcpConfigs = configs


### PR DESCRIPTION
## 改动摘要

为 NP Manager 桥接新增 **SSE (Server-Sent Events)** 传输支持，MT Manager 保持 HTTP 不变。

## 核心改动

### 1. 配置层：`BridgeConfig` 增加 `transport` 字段
- 新增 `transport: String = "auto"`，可选值：`auto` / `http` / `sse`
- 默认桥接初始化时：
  - MT Manager (`:8787`) → `auto`
  - NP Manager (`:8788`) → `sse`
- `apkMcpConfigs` 的序列化/反序列化、`snapshot`、`applyPatch` 均支持 `transport` 字段

### 2. 桥接引擎：`ApkMcpBridge` 增加 SSE 客户端
- 新增内部类 `SseClient`，基于 OkHttp `EventSource` 实现 MCP-over-SSE
- `BridgeConnection` 增加 `transport` 构造参数与 `shouldUseSse()` 判断
- `probe` / `ping` / `callTool` / `startHealthMonitor` 根据 transport 配置路由到：
  - `auto` / `sse` → SSE 传输（默认 NP Manager 走 SSE）
  - `http` → 传统 HTTP 传输（MT Manager 不受影响）
- 健康监控线程同样按 transport 分流

## 向后兼容
- 旧版配置中没有 `transport` 字段时，默认回退到 `auto` 行为
- MT Manager 的 `:8787` 端口在 `auto` 模式下仍走原有 HTTP 路径
- 用户可通过 `apkMcpConfigs` 显式设置 `"transport": "http"` 或 `"transport": "sse"` 覆盖默认行为

## 验证建议
1. NP Manager (`:8788`) 正常发现工具列表（SSE 模式）
2. MT Manager (`:8787`) 仍正常发现工具列表（HTTP 模式）
3. 同时在线时 `mergedTools()` 返回两组前缀的工具
4. 健康监控不会互相影响
