### PR TITLE
fix: downgrade argon2kt from 1.7.0 to 1.6.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -166,5 +166,5 @@ dependencies {
     testImplementation("org.json:json:20250517")
 
     // Argon2 key derivation for encrypted backup/restore
-    implementation("com.lambdapioneer.argon2kt:argon2kt:1.7.0")
+    implementation("com.lambdapioneer.argon2kt:argon2kt:1.6.0")
 }


### PR DESCRIPTION
## 问题

CI 构建失败，依赖解析报错：

```
Could not find com.lambdapioneer.argon2kt:argon2kt:1.7.0.
```

`lambdapioneer/argon2kt` 官方 Releases 最高只到 **1.6.0**，`1.7.0` 并不存在，因此配置缓存后构建始终失败。

## 修复

将 `app/build.gradle.kts` 中的版本从 `1.7.0` 降级到 `1.6.0`：

```kotlin
// Argon2 key derivation for encrypted backup/restore
implementation("com.lambdapioneer.argon2kt:argon2kt:1.6.0")
```

## 影响范围

恢复 **1.0.17** 版本引入的加密备份/恢复功能（`BackupCrypto.kt` 使用的 `Argon2Kt` + `Argon2Mode.ARGON2ID` API 在 `1.6.0` 中保持兼容）。

## 验证建议

重新跑一次 CI 的 `:app:lintDebug` / `assembleDebug`，确认依赖可正常解析。