### PR TITLE
fix: heap overflow, integer wrap and UB in native APK signature parser

### DIFF
--- a/app/src/main/cpp/blutter_bridge.cpp
+++ b/app/src/main/cpp/blutter_bridge.cpp
@@ -45,11 +45,15 @@ Java_com_soreverse_mcp_blutter_NativeBlutterBridge_nativeRun(JNIEnv* env, jobjec
         throw_runtime(env, "Invalid Blutter runner arguments");
         return -1;
     }
+    // Acquire and check one at a time. Fetching both before the null check leaked
+    // the first buffer whenever the second allocation failed (OOM on a long
+    // options payload), and left a pending OutOfMemoryError unhandled.
     const char* raw_library = env->GetStringUTFChars(library_name, nullptr);
-    const char* raw_options = env->GetStringUTFChars(options_json, nullptr);
-    if (raw_library == nullptr || raw_options == nullptr) return -1;
+    if (raw_library == nullptr) return -1;
     std::string library(raw_library);
     env->ReleaseStringUTFChars(library_name, raw_library);
+    const char* raw_options = env->GetStringUTFChars(options_json, nullptr);
+    if (raw_options == nullptr) return -1;
     if (!valid_library(library)) {
         env->ReleaseStringUTFChars(options_json, raw_options);
         throw_runtime(env, "Rejected Blutter runner library name");

--- a/app/src/main/cpp/signature_verify.cpp
+++ b/app/src/main/cpp/signature_verify.cpp
@@ -91,18 +91,31 @@ struct ZipLocalFileHeader {
 // Minimal DER/PKCS7 parser
 // ---------------------------------------------------------------------------
 struct DerNode {
-    uint8_t tag;
-    bool constructed;
+    // Default-initialized: parse_der has several early-return paths (truncated
+    // header, bad length form, depth limit) that return a node without ever
+    // assigning these. Callers compare `tag` to decide whether a child parsed,
+    // so leaving them indeterminate would make that check read uninitialized
+    // memory and the sibling loop terminate unpredictably.
+    uint8_t tag = 0;
+    bool constructed = false;
+    bool parsed = false;          // true once a header was successfully decoded
     std::vector<uint8_t> value;   // raw value bytes (tag+length stripped)
     std::vector<DerNode> children;
 };
 
-static DerNode parse_der(const uint8_t* data, size_t offset, size_t end) {
+// Maximum DER nesting depth. A PKCS7 SignedData certificate chain nests ~8
+// levels; 16 is generous while bounding recursion so a hostile/corrupt
+// signature block cannot drive parse_der into a stack overflow.
+static const int kMaxDerDepth = 16;
+
+static DerNode parse_der(const uint8_t* data, size_t offset, size_t end, int depth = 0) {
     DerNode node;
     if (offset + 2 > end) return node;
+    if (depth > kMaxDerDepth) return node;
 
     node.tag = data[offset];
     node.constructed = (node.tag & 0x20) != 0;
+    node.parsed = true;
     size_t pos = offset + 1;
 
     // Length
@@ -125,80 +138,39 @@ static DerNode parse_der(const uint8_t* data, size_t offset, size_t end) {
 
     node.value.assign(data + pos, data + pos + length);
 
-    // Parse children for constructed tags
-    if (node.constructed) {
+    // Parse children for constructed tags. Decode each child's header locally so
+    // progress is measured against node.value rather than against a separately
+    // allocated child.value vector (subtracting those unrelated pointers was UB).
+    if (node.constructed && depth < kMaxDerDepth) {
         size_t child_pos = 0;
         while (child_pos < node.value.size()) {
-            auto child = parse_der(node.value.data(), child_pos, node.value.size());
-            if (child.value.empty() && child.children.empty()) break;
-            node.children.push_back(child);
-            child_pos += (child.tag == 0) ? 0 : (child.value.data() - node.value.data() + child.value.size() - child_pos);
-            // Better: advance by the full encoded length
-            // Recalculate:
-            size_t consumed = 0;
-            for (const auto& c : node.children) {
-                consumed += 2; // tag + length (at minimum)
-                if (c.value.size() > 127) consumed += (c.value.size() > 255) ? 3 : 2; // long-form length
-                consumed += c.value.size();
-            }
-            child_pos = consumed;
-        }
-        // Re-parse more accurately
-        node.children.clear();
-        child_pos = 0;
-        while (child_pos < node.value.size()) {
-            // Skip tag byte
-            if (child_pos >= node.value.size()) break;
+            if (node.value.size() - child_pos < 2) break;
             uint8_t child_tag = node.value[child_pos];
-            size_t child_len_pos = child_pos + 1;
-            if (child_len_pos >= node.value.size()) break;
-
+            size_t len_pos = child_pos + 1;
             size_t child_length = 0;
-            size_t child_len_bytes = 1;
-            if (node.value[child_len_pos] & 0x80) {
-                child_len_bytes = (node.value[child_len_pos] & 0x7f) + 1;
-                if (child_len_bytes > 5) break;
-                for (size_t i = 1; i < child_len_bytes; i++) {
-                    if (child_len_pos + i >= node.value.size()) { child_len_bytes = 0; break; }
-                    child_length = (child_length << 8) | node.value[child_len_pos + i];
+            size_t length_field_size = 1;
+            if (node.value[len_pos] & 0x80) {
+                const size_t length_octets = node.value[len_pos] & 0x7f;
+                if (length_octets == 0 || length_octets > 4 ||
+                    length_octets > node.value.size() - len_pos - 1) break;
+                length_field_size += length_octets;
+                for (size_t i = 0; i < length_octets; ++i) {
+                    child_length = (child_length << 8) | node.value[len_pos + 1 + i];
                 }
-                if (child_len_bytes == 0) break;
             } else {
-                child_length = node.value[child_len_pos];
+                child_length = node.value[len_pos];
             }
-
-            size_t header_size = 1 + child_len_bytes;
-            size_t child_end = child_pos + header_size + child_length;
-            if (child_end > node.value.size()) break;
-
-            DerNode child;
-            child.tag = child_tag;
-            child.constructed = (child_tag & 0x20) != 0;
-            child.value.assign(node.value.data() + child_pos + header_size,
-                               node.value.data() + child_end);
-            if (child.constructed) {
-                // Recursively parse children
-                // (skip for now, we only need the leaf certificate)
-            }
-            node.children.push_back(child);
+            const size_t header_size = 1 + length_field_size;
+            if (child_length > node.value.size() - child_pos - header_size) break;
+            const size_t child_end = child_pos + header_size + child_length;
+            auto child = parse_der(node.value.data(), child_pos, child_end, depth + 1);
+            if (child.tag != child_tag) break;
+            node.children.push_back(std::move(child));
             child_pos = child_end;
         }
     }
 
     return node;
-}
-
-// Find a child node by tag (recursive, first match)
-static const DerNode* find_der_child(const DerNode* node, uint8_t tag) {
-    if (!node) return nullptr;
-    for (const auto& child : node->children) {
-        if (child.tag == tag) return &child;
-    }
-    for (const auto& child : node->children) {
-        auto* found = find_der_child(&child, tag);
-        if (found) return found;
-    }
-    return nullptr;
 }
 
 // Find a child node by tag at direct children only
@@ -208,24 +180,6 @@ static const DerNode* find_direct_child(const DerNode* node, uint8_t tag) {
         if (child.tag == tag) return &child;
     }
     return nullptr;
-}
-
-// Find a child node by walking a tag path
-static const DerNode* find_der_path(const DerNode* node, std::initializer_list<uint8_t> tags) {
-    const DerNode* current = node;
-    for (uint8_t tag : tags) {
-        if (!current) return nullptr;
-        bool found = false;
-        for (const auto& child : current->children) {
-            if (child.tag == tag) {
-                current = &child;
-                found = true;
-                break;
-            }
-        }
-        if (!found) return nullptr;
-    }
-    return current;
 }
 
 // Extract X.509 certificate from a PKCS7 SignedData (.RSA/.DSA/.EC file)
@@ -246,18 +200,11 @@ static std::vector<uint8_t> extract_certificate_from_pkcs7(const std::vector<uin
     }
     if (content_info->tag != 0x30) return {};
 
-    // Find SignedData content [0] (context-specific, constructed, tag 0xa0)
-    auto* signed_data_wrapper = find_der_path(content_info, {0x30, 0xa0});
-    // Actually, let's just find it more directly
-    // ContentInfo.SEQUENCE -> first child is OID (0x06), second is [0] (0xa0)
+    // ContentInfo.SEQUENCE -> first child is the OID (0x06), second is the
+    // [0] EXPLICIT wrapper (0xa0) whose single child is the SignedData SEQUENCE.
     const DerNode* signed_data = nullptr;
-    for (const auto& child : content_info->children) {
-        if (child.tag == 0xa0) {
-            // [0] EXPLICIT -> SignedData SEQUENCE inside
-            if (!child.children.empty() && child.children[0].tag == 0x30) {
-                signed_data = &child.children[0];
-            }
-        }
+    if (const DerNode* wrapper = find_direct_child(content_info, 0xa0)) {
+        signed_data = find_direct_child(wrapper, 0x30);
     }
     if (!signed_data) return {};
 
@@ -275,11 +222,18 @@ static std::vector<uint8_t> extract_certificate_from_pkcs7(const std::vector<uin
             // Each child is a SEQUENCE (Certificate)
             for (const auto& cert : child.children) {
                 if (cert.tag == 0x30) { // SEQUENCE = Certificate
-                    // Reconstruct the full DER-encoded certificate
-                    // Tag + length + value
+                    // Re-emit tag + definite length + value so the caller receives
+                    // a self-contained DER certificate.
+                    const size_t total_len = cert.value.size();
+                    // 0x82 is the widest length form emitted below; anything larger
+                    // would need 0x83/0x84 and silently truncating the length would
+                    // hand Java a corrupt certificate.
+                    if (total_len > 0xffff) {
+                        LOGE("Certificate too large to re-encode: %zu bytes", total_len);
+                        return {};
+                    }
                     std::vector<uint8_t> result;
-                    // Construct the full DER encoding
-                    size_t total_len = cert.value.size();
+                    result.reserve(total_len + 4);
                     result.push_back(0x30); // SEQUENCE tag
                     if (total_len < 128) {
                         result.push_back(static_cast<uint8_t>(total_len));
@@ -424,57 +378,40 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeGetExpectedSignerDiges
 }
 
 /**
- * Reads the APK file directly from the filesystem and extracts the first
- * X.509 signing certificate from the META-INF/*.RSA/.DSA/.EC signature file.
+ * Reads the APK at [path] and returns the first X.509 signing certificate found
+ * in its META-INF v1 signature block, or an empty vector on any failure.
  *
- * This bypasses the Java PackageManager API, which is what kstools and
- * ApkSignatureKiller hook to replace signatures.
- *
- * @param env       JNI environment
- * @param thiz      JNI object
- * @param apkPath   Absolute path to the APK file (e.g., context.packageCodePath)
- * @return          DER-encoded X.509 certificate bytes, or null on failure
+ * Split out of the JNI entry point so the ZIP/PKCS7 parsing can be exercised
+ * directly by a host-side test harness with no JVM present.
  */
-extern "C" JNIEXPORT jbyteArray JNICALL
-Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
-    JNIEnv* env, jobject thiz, jstring apkPath) {
-
-    if (!apkPath) {
-        LOGE("apkPath is null");
-        return nullptr;
-    }
-
-    const char* path_cstr = env->GetStringUTFChars(apkPath, nullptr);
-    std::string path(path_cstr);
-    env->ReleaseStringUTFChars(apkPath, path_cstr);
-
+static std::vector<uint8_t> read_apk_certificate(const std::string& path) {
     LOGI("Reading APK: %s", path.c_str());
 
     // Read the entire APK file
     std::ifstream file(path, std::ios::binary | std::ios::ate);
     if (!file.is_open()) {
         LOGE("Failed to open APK: %s", path.c_str());
-        return nullptr;
+        return {};
     }
 
     std::streamsize size = file.tellg();
     if (size <= 0) {
         LOGE("APK file is empty");
-        return nullptr;
+        return {};
     }
 
     std::vector<uint8_t> apk_data(static_cast<size_t>(size));
     file.seekg(0, std::ios::beg);
     if (!file.read(reinterpret_cast<char*>(apk_data.data()), size)) {
         LOGE("Failed to read APK file");
-        return nullptr;
+        return {};
     }
     file.close();
 
     // Find End of Central Directory
     if (apk_data.size() < sizeof(ZipEocd)) {
         LOGE("APK too small");
-        return nullptr;
+        return {};
     }
 
     // Search for EOCD signature from the end (with max comment length)
@@ -496,7 +433,7 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
 
     if (!found_eocd) {
         LOGE("EOCD not found");
-        return nullptr;
+        return {};
     }
 
     ZipEocd eocd;
@@ -504,9 +441,11 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
     LOGI("Central dir: offset=%u, size=%u, entries=%u",
          eocd.central_dir_offset, eocd.central_dir_size, eocd.total_entries);
 
-    if (eocd.central_dir_offset + eocd.central_dir_size > apk_data.size()) {
+    const uint64_t central_dir_end = static_cast<uint64_t>(eocd.central_dir_offset) +
+                                     static_cast<uint64_t>(eocd.central_dir_size);
+    if (central_dir_end > apk_data.size()) {
         LOGE("Central directory exceeds file bounds");
-        return nullptr;
+        return {};
     }
 
     // Scan central directory for META-INF signature files
@@ -570,32 +509,31 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
                     continue;
                 }
 
-                size_t data_offset = local_offset + sizeof(ZipLocalFileHeader) +
-                                     local.filename_length + local.extra_length;
-
-                if (data_offset + entry.compressed_size > apk_data.size()) {
+                const uint64_t data_offset = static_cast<uint64_t>(local_offset) +
+                                             sizeof(ZipLocalFileHeader) +
+                                             static_cast<uint64_t>(local.filename_length) +
+                                             static_cast<uint64_t>(local.extra_length);
+                const uint64_t compressed_end = data_offset + static_cast<uint64_t>(entry.compressed_size);
+                if (data_offset > apk_data.size() || compressed_end > apk_data.size()) {
                     LOGE("File data out of bounds for %s", filename.c_str());
                     continue;
                 }
 
-                // For META-INF signature files, compression is typically 0 (stored)
-                if (entry.compression == 0) {
-                    signature_file_data.assign(
-                        apk_data.data() + data_offset,
-                        apk_data.data() + data_offset + entry.uncompressed_size);
-                    signature_filename = filename;
-                    LOGI("Read signature file: %s (%zu bytes)", filename.c_str(), signature_file_data.size());
-                    break;
-                } else {
-                    LOGI("Signature file %s is compressed (type %u), trying to read raw",
-                         filename.c_str(), entry.compression);
-                    // Read compressed data anyway, the PKCS7 parser might still work
-                    signature_file_data.assign(
-                        apk_data.data() + data_offset,
-                        apk_data.data() + data_offset + entry.compressed_size);
-                    signature_filename = filename;
-                    break;
+                // APK v1 signature blocks must be stored: compressed PKCS7 data
+                // is not DER, and accepting it would either parse garbage or read
+                // a misleading certificate candidate. For stored entries both ZIP
+                // sizes must agree before using either one as a range length.
+                if (entry.compression != 0 || entry.compressed_size != entry.uncompressed_size) {
+                    LOGE("Unsupported signature entry %s (compression=%u, compressed=%u, uncompressed=%u)",
+                         filename.c_str(), entry.compression, entry.compressed_size, entry.uncompressed_size);
+                    continue;
                 }
+                signature_file_data.assign(
+                    apk_data.data() + static_cast<size_t>(data_offset),
+                    apk_data.data() + static_cast<size_t>(compressed_end));
+                signature_filename = filename;
+                LOGI("Read signature file: %s (%zu bytes)", filename.c_str(), signature_file_data.size());
+                break;
             }
         }
 
@@ -605,7 +543,7 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
 
     if (signature_file_data.empty()) {
         LOGE("No signature file found in META-INF");
-        return nullptr;
+        return {};
     }
 
     LOGI("Signature file size: %zu bytes", signature_file_data.size());
@@ -619,12 +557,49 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
 
     if (cert.empty()) {
         LOGE("Failed to extract certificate from signature file");
-        return nullptr;
+        return {};
     }
 
     LOGI("Extracted certificate: %zu bytes", cert.size());
+    return cert;
+}
 
-    // Return the certificate bytes to Java
+#ifdef SOMCP_TEST_HARNESS
+// Host-side entry point for the parser tests. Never compiled into the APK.
+std::vector<uint8_t> somcp_test_read_apk_certificate(const std::string& path) {
+    return read_apk_certificate(path);
+}
+#endif
+
+/**
+ * Reads the APK file directly from the filesystem and extracts the first
+ * X.509 signing certificate from the META-INF/ *.RSA/.DSA/.EC signature file.
+ *
+ * This bypasses the Java PackageManager API, which is what kstools and
+ * ApkSignatureKiller hook to replace signatures.
+ *
+ * @param env       JNI environment
+ * @param thiz      JNI object
+ * @param apkPath   Absolute path to the APK file (e.g., context.packageCodePath)
+ * @return          DER-encoded X.509 certificate bytes, or null on failure
+ */
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
+    JNIEnv* env, jobject thiz, jstring apkPath) {
+
+    if (!apkPath) {
+        LOGE("apkPath is null");
+        return nullptr;
+    }
+
+    const char* path_cstr = env->GetStringUTFChars(apkPath, nullptr);
+    if (!path_cstr) return nullptr;
+    std::string path(path_cstr);
+    env->ReleaseStringUTFChars(apkPath, path_cstr);
+
+    const std::vector<uint8_t> cert = read_apk_certificate(path);
+    if (cert.empty()) return nullptr;
+
     jbyteArray result = env->NewByteArray(static_cast<jsize>(cert.size()));
     if (!result) {
         LOGE("Failed to allocate Java byte array");

--- a/tools/native-tests/run.sh
+++ b/tools/native-tests/run.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-only
+# SOMCP - Android native SO reverse-engineering MCP server
+# Copyright (C) 2026 SOMCP authors <https://github.com/bilieebiliee1-design/SOMCP>
+# This file is part of SOMCP and is licensed under the GNU General Public License v3.0.
+# Host-side tests for the native APK signature parser (app/src/main/cpp/signature_verify.cpp).
+#
+# These run on the build machine with any C++17 compiler; no device, NDK or JVM is
+# needed. The stub/ directory supplies the few Android headers the translation
+# unit includes. Sanitizers are enabled because the cases here deliberately feed
+# malformed ZIP/DER structures at the parser.
+#
+# Usage:
+#   tools/native-tests/run.sh            # uses c++ from PATH
+#   CXX=clang++ tools/native-tests/run.sh
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cxx=${CXX:-c++}
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "[native-tests] compiling with $cxx"
+"$cxx" -std=c++17 -g -O1 \
+    -fsanitize=address,undefined -fno-omit-frame-pointer \
+    -DSOMCP_TEST_HARNESS \
+    -DSOMCP_TEST_TMPDIR="\"$tmp\"" \
+    -I"$here/stub" \
+    -Wall -Wextra -Wno-unused-parameter -Wno-comment -Wno-unused-const-variable \
+    -o "$tmp/signature_verify_test" \
+    "$here/signature_verify_test.cpp"
+
+echo "[native-tests] running"
+ASAN_OPTIONS=detect_leaks=0 "$tmp/signature_verify_test"

--- a/tools/native-tests/signature_verify_test.cpp
+++ b/tools/native-tests/signature_verify_test.cpp
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SOMCP - Android native SO reverse-engineering MCP server
+// Copyright (C) 2026 SOMCP authors <https://github.com/bilieebiliee1-design/SOMCP>
+// This file is part of SOMCP and is licensed under the GNU General Public License v3.0.
+// Functional harness for signature_verify.cpp's ZIP + PKCS7 parsing.
+//
+// Compiles the production translation unit with SOMCP_TEST_HARNESS defined so the
+// JNI entry points are replaced by a plain C++ entry that takes a file path. Each
+// case below exercises one of the defects fixed in this branch.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+// Pull in the implementation under test. SOMCP_TEST_HARNESS exposes
+// somcp_test_read_apk_certificate() in place of the JNI entry point.
+#include "../../app/src/main/cpp/signature_verify.cpp"
+
+#ifndef SOMCP_TEST_TMPDIR
+#define SOMCP_TEST_TMPDIR "."
+#endif
+
+static int g_failures = 0;
+static int g_checks = 0;
+
+static void check(bool cond, const char* name, const char* detail = "") {
+    ++g_checks;
+    if (cond) {
+        printf("  PASS  %s %s\n", name, detail);
+    } else {
+        printf("  FAIL  %s %s\n", name, detail);
+        ++g_failures;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Byte assembly helpers
+// ---------------------------------------------------------------------------
+static void put16(std::vector<uint8_t>& out, uint16_t v) {
+    out.push_back(v & 0xff);
+    out.push_back((v >> 8) & 0xff);
+}
+static void put32(std::vector<uint8_t>& out, uint32_t v) {
+    out.push_back(v & 0xff);
+    out.push_back((v >> 8) & 0xff);
+    out.push_back((v >> 16) & 0xff);
+    out.push_back((v >> 24) & 0xff);
+}
+static void putBytes(std::vector<uint8_t>& out, const std::vector<uint8_t>& v) {
+    out.insert(out.end(), v.begin(), v.end());
+}
+
+// DER TLV with definite length.
+static std::vector<uint8_t> der(uint8_t tag, const std::vector<uint8_t>& value) {
+    std::vector<uint8_t> out;
+    out.push_back(tag);
+    const size_t n = value.size();
+    if (n < 128) {
+        out.push_back(static_cast<uint8_t>(n));
+    } else if (n < 256) {
+        out.push_back(0x81);
+        out.push_back(static_cast<uint8_t>(n));
+    } else {
+        out.push_back(0x82);
+        out.push_back(static_cast<uint8_t>((n >> 8) & 0xff));
+        out.push_back(static_cast<uint8_t>(n & 0xff));
+    }
+    out.insert(out.end(), value.begin(), value.end());
+    return out;
+}
+
+static std::vector<uint8_t> concat(std::initializer_list<std::vector<uint8_t>> parts) {
+    std::vector<uint8_t> out;
+    for (const auto& p : parts) out.insert(out.end(), p.begin(), p.end());
+    return out;
+}
+
+// A recognisable fake X.509: SEQUENCE { SEQUENCE(tbs) , BITSTRING(sig) }.
+// `marker` is embedded so we can prove which certificate came back.
+static std::vector<uint8_t> makeCert(uint8_t marker, size_t tbsPadding) {
+    std::vector<uint8_t> tbsBody(tbsPadding, marker);
+    auto tbs = der(0x30, tbsBody);
+    auto sig = der(0x03, std::vector<uint8_t>(16, 0x5a));
+    return der(0x30, concat({tbs, sig}));
+}
+
+// PKCS7 ContentInfo { OID signedData, [0] { SignedData { ver, digestAlgs,
+// contentInfo, [0] certificates } } }
+static std::vector<uint8_t> makePkcs7(const std::vector<std::vector<uint8_t>>& certs) {
+    auto version = der(0x02, {0x01});
+    auto digestAlgs = der(0x31, {});
+    auto encapInfo = der(0x30, der(0x06, {0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x07, 0x01}));
+    std::vector<uint8_t> certBlob;
+    for (const auto& c : certs) certBlob.insert(certBlob.end(), c.begin(), c.end());
+    auto certificates = der(0xa0, certBlob);
+    auto signerInfos = der(0x31, {});
+    auto signedData = der(0x30, concat({version, digestAlgs, encapInfo, certificates, signerInfos}));
+    auto wrapper = der(0xa0, signedData);
+    auto oid = der(0x06, {0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x07, 0x02});
+    return der(0x30, concat({oid, wrapper}));
+}
+
+struct ZipEntrySpec {
+    std::string name;
+    std::vector<uint8_t> data;
+    uint16_t compression = 0;
+    // Overrides used to forge malformed archives; 0 means "use the real value".
+    uint32_t forcedUncompressedSize = 0;
+    uint32_t forcedCompressedSize = 0;
+};
+
+struct ZipOverrides {
+    uint32_t centralDirOffset = 0;   // 0 = real
+    uint32_t centralDirSize = 0;     // 0 = real
+};
+
+static std::vector<uint8_t> buildZip(const std::vector<ZipEntrySpec>& entries,
+                                     const ZipOverrides& ov = {}) {
+    std::vector<uint8_t> out;
+    std::vector<uint32_t> localOffsets;
+
+    for (const auto& e : entries) {
+        localOffsets.push_back(static_cast<uint32_t>(out.size()));
+        put32(out, 0x04034b50);
+        put16(out, 20);
+        put16(out, 0);
+        put16(out, e.compression);
+        put16(out, 0);
+        put16(out, 0);
+        put32(out, 0);
+        put32(out, e.forcedCompressedSize ? e.forcedCompressedSize : static_cast<uint32_t>(e.data.size()));
+        put32(out, e.forcedUncompressedSize ? e.forcedUncompressedSize : static_cast<uint32_t>(e.data.size()));
+        put16(out, static_cast<uint16_t>(e.name.size()));
+        put16(out, 0);
+        out.insert(out.end(), e.name.begin(), e.name.end());
+        putBytes(out, e.data);
+    }
+
+    const uint32_t cdStart = static_cast<uint32_t>(out.size());
+    for (size_t i = 0; i < entries.size(); ++i) {
+        const auto& e = entries[i];
+        put32(out, 0x02014b50);
+        put16(out, 20);
+        put16(out, 20);
+        put16(out, 0);
+        put16(out, e.compression);
+        put16(out, 0);
+        put16(out, 0);
+        put32(out, 0);
+        put32(out, e.forcedCompressedSize ? e.forcedCompressedSize : static_cast<uint32_t>(e.data.size()));
+        put32(out, e.forcedUncompressedSize ? e.forcedUncompressedSize : static_cast<uint32_t>(e.data.size()));
+        put16(out, static_cast<uint16_t>(e.name.size()));
+        put16(out, 0);
+        put16(out, 0);
+        put16(out, 0);
+        put16(out, 0);
+        put32(out, 0);
+        put32(out, localOffsets[i]);
+        out.insert(out.end(), e.name.begin(), e.name.end());
+    }
+    const uint32_t cdSize = static_cast<uint32_t>(out.size()) - cdStart;
+
+    put32(out, 0x06054b50);
+    put16(out, 0);
+    put16(out, 0);
+    put16(out, static_cast<uint16_t>(entries.size()));
+    put16(out, static_cast<uint16_t>(entries.size()));
+    put32(out, ov.centralDirSize ? ov.centralDirSize : cdSize);
+    put32(out, ov.centralDirOffset ? ov.centralDirOffset : cdStart);
+    put16(out, 0);
+    return out;
+}
+
+static std::string writeTemp(const std::string& name, const std::vector<uint8_t>& data) {
+    std::string path = std::string(SOMCP_TEST_TMPDIR) + "/" + name;
+    FILE* f = fopen(path.c_str(), "wb");
+    if (!f) {
+        printf("  FAIL  could not write fixture %s\n", path.c_str());
+        ++g_failures;
+        return path;
+    }
+    if (!data.empty()) fwrite(data.data(), 1, data.size(), f);
+    fclose(f);
+    return path;
+}
+
+int main() {
+    printf("signature_verify parser harness\n\n");
+
+    const auto certA = makeCert(0xAA, 200);
+    const auto certB = makeCert(0xBB, 300);
+
+    // ---- Case 1: well-formed stored .RSA yields the first certificate ----
+    printf("case 1: well-formed v1 signature block\n");
+    {
+        auto pkcs7 = makePkcs7({certA, certB});
+        auto zip = buildZip({
+            {"AndroidManifest.xml", std::vector<uint8_t>(64, 0x11)},
+            {"META-INF/CERT.RSA", pkcs7},
+        });
+        auto path = writeTemp("case1.apk", zip);
+        auto got = somcp_test_read_apk_certificate(path);
+        check(!got.empty(), "certificate extracted");
+        check(got == certA, "matches the first certificate in the SET",
+              got == certA ? "" : "(wrong certificate returned)");
+    }
+
+    // ---- Case 2: uncompressed_size >> compressed_size must not over-read ----
+    // This is the P0-A out-of-bounds read: the guard used compressed_size while
+    // the copy used uncompressed_size.
+    printf("\ncase 2: forged uncompressed_size (out-of-bounds read attempt)\n");
+    {
+        auto pkcs7 = makePkcs7({certA});
+        ZipEntrySpec sig{"META-INF/CERT.RSA", pkcs7};
+        sig.forcedUncompressedSize = 0x0FFFFFFF;  // ~256 MiB, file is ~1 KiB
+        auto zip = buildZip({{"a.txt", std::vector<uint8_t>(16, 0x22)}, sig});
+        auto path = writeTemp("case2.apk", zip);
+        auto got = somcp_test_read_apk_certificate(path);
+        check(got.empty(), "entry rejected instead of over-reading the heap");
+    }
+
+    // ---- Case 3: central directory offset+size wraps uint32 ----
+    // P0-B: the bounds check added two uint32 values before widening.
+    printf("\ncase 3: central directory offset/size uint32 wrap\n");
+    {
+        auto pkcs7 = makePkcs7({certA});
+        ZipOverrides ov;
+        ov.centralDirOffset = 0xFFFFFF00u;
+        ov.centralDirSize = 0x200u;  // wraps to 0x100 in 32-bit math
+        auto zip = buildZip({{"META-INF/CERT.RSA", pkcs7}}, ov);
+        auto path = writeTemp("case3.apk", zip);
+        auto got = somcp_test_read_apk_certificate(path);
+        check(got.empty(), "wrapped central directory rejected");
+    }
+
+    // ---- Case 4: deflated signature entry is refused ----
+    printf("\ncase 4: deflated signature entry\n");
+    {
+        auto pkcs7 = makePkcs7({certA});
+        ZipEntrySpec sig{"META-INF/CERT.RSA", pkcs7};
+        sig.compression = 8;  // deflate
+        auto zip = buildZip({sig});
+        auto path = writeTemp("case4.apk", zip);
+        auto got = somcp_test_read_apk_certificate(path);
+        check(got.empty(), "compressed PKCS7 not treated as DER");
+    }
+
+    // ---- Case 5: DER parser terminates on hostile nesting ----
+    // P0-C: the discarded first child loop could spin forever.
+    printf("\ncase 5: DER parser termination\n");
+    {
+        // 40 levels of nested SEQUENCEs, past kMaxDerDepth.
+        std::vector<uint8_t> deep = der(0x02, {0x01});
+        for (int i = 0; i < 40; ++i) deep = der(0x30, deep);
+        auto node = parse_der(deep.data(), 0, deep.size());
+        check(true, "deeply nested input returned (no hang, no stack overflow)");
+
+        // Truncated/garbage bodies must also terminate.
+        std::vector<uint8_t> garbage = der(0x30, std::vector<uint8_t>(64, 0xff));
+        auto g = parse_der(garbage.data(), 0, garbage.size());
+        check(true, "garbage constructed body returned");
+
+        // A zero-length child must still advance the cursor.
+        auto emptyChildren = der(0x30, concat({der(0x05, {}), der(0x05, {}), der(0x02, {0x07})}));
+        auto e = parse_der(emptyChildren.data(), 0, emptyChildren.size());
+        check(e.children.size() == 3, "zero-length children each advance the cursor",
+              ("children=" + std::to_string(e.children.size())).c_str());
+    }
+
+    // ---- Case 6: recursion populates nested children ----
+    // The old parser never recursed, so extract_certificate_from_pkcs7 always
+    // fell through to the loose byte-scanning fallback.
+    printf("\ncase 6: structured extraction (not fallback)\n");
+    {
+        auto pkcs7 = makePkcs7({certA});
+        auto structured = extract_certificate_from_pkcs7(pkcs7);
+        check(!structured.empty(), "structured PKCS7 path returns a certificate");
+        check(structured == certA, "structured path picked the real certificate");
+    }
+
+    // ---- Case 7: no signature file at all ----
+    printf("\ncase 7: archive without META-INF signature\n");
+    {
+        auto zip = buildZip({{"classes.dex", std::vector<uint8_t>(32, 0x33)}});
+        auto path = writeTemp("case7.apk", zip);
+        auto got = somcp_test_read_apk_certificate(path);
+        check(got.empty(), "missing signature reported as failure");
+    }
+
+    // ---- Case 8: truncated / empty inputs ----
+    printf("\ncase 8: degenerate inputs\n");
+    {
+        auto p1 = writeTemp("case8a.apk", {});
+        check(somcp_test_read_apk_certificate(p1).empty(), "empty file");
+        auto p2 = writeTemp("case8b.apk", std::vector<uint8_t>{0x50, 0x4b, 0x03, 0x04});
+        check(somcp_test_read_apk_certificate(p2).empty(), "4-byte file");
+        auto p3 = writeTemp("case8c.apk", std::vector<uint8_t>(80, 0x00));
+        check(somcp_test_read_apk_certificate(p3).empty(), "no EOCD signature");
+        check(somcp_test_read_apk_certificate("/nonexistent/path.apk").empty(), "missing file");
+    }
+
+    // ---- Case 9: expected signer digest decodes ----
+    printf("\ncase 9: obfuscated expected digest\n");
+    {
+        auto digest = decode_xor_hex(kEncodedExpectedSha256, kEncodedExpectedSha256Len);
+        check(digest == "90FEDAC1F020C6C5D1DD1A635DB5C3B7579F5B87647E2C2C00966D3BCB0F8B6F",
+              "XOR-encoded pin decodes to the documented value", digest.c_str());
+    }
+
+    printf("\n%d checks, %d failures\n", g_checks, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tools/native-tests/stub/android/asset_manager.h
+++ b/tools/native-tests/stub/android/asset_manager.h
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SOMCP - Android native SO reverse-engineering MCP server
+// Copyright (C) 2026 SOMCP authors <https://github.com/bilieebiliee1-design/SOMCP>
+// This file is part of SOMCP and is licensed under the GNU General Public License v3.0.
+#pragma once
+typedef struct AAssetManager AAssetManager;

--- a/tools/native-tests/stub/android/asset_manager_jni.h
+++ b/tools/native-tests/stub/android/asset_manager_jni.h
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SOMCP - Android native SO reverse-engineering MCP server
+// Copyright (C) 2026 SOMCP authors <https://github.com/bilieebiliee1-design/SOMCP>
+// This file is part of SOMCP and is licensed under the GNU General Public License v3.0.
+#pragma once
+#include <android/asset_manager.h>

--- a/tools/native-tests/stub/android/log.h
+++ b/tools/native-tests/stub/android/log.h
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SOMCP - Android native SO reverse-engineering MCP server
+// Copyright (C) 2026 SOMCP authors <https://github.com/bilieebiliee1-design/SOMCP>
+// This file is part of SOMCP and is licensed under the GNU General Public License v3.0.
+#pragma once
+#include "../shim.h"

--- a/tools/native-tests/stub/shim.h
+++ b/tools/native-tests/stub/shim.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// SOMCP - Android native SO reverse-engineering MCP server
+// Copyright (C) 2026 SOMCP authors <https://github.com/bilieebiliee1-design/SOMCP>
+// This file is part of SOMCP and is licensed under the GNU General Public License v3.0.
+// Minimal Android logging shim so signature_verify.cpp compiles off-device.
+#pragma once
+#include <cstdio>
+#define ANDROID_LOG_INFO 4
+#define ANDROID_LOG_ERROR 6
+static inline int __android_log_print(int, const char*, const char* fmt, ...) {
+    (void)fmt;
+    return 0;
+}


### PR DESCRIPTION
fix: heap overflow, integer wrap and UB in native APK signature parser

Three defects in the filesystem-level signature verifier that runs on every
startup via IntegrityGuard.enforce() -> SignatureVerifier.verify(). All three
are reachable by opening a crafted APK, and the parser is the code that is
supposed to defend against signature-killer hooking.

1. Heap buffer overflow reading a stored signature entry

   The bounds check validated `data_offset + compressed_size`, but the stored
   branch then copied `uncompressed_size` bytes. ZIP does not enforce that the
   two agree, so a central directory declaring a small compressed_size and a
   large uncompressed_size reads far past the buffer. AddressSanitizer on a
   crafted APK:

       AddressSanitizer: heap-buffer-overflow
       READ of size 268435455
       0 bytes after 502-byte region
       #12 read_apk_certificate signature_verify.cpp:572

   Fixed by requiring compressed_size == uncompressed_size for stored entries
   and rejecting the entry otherwise. Deflated signature entries are now
   rejected outright: compressed PKCS7 is not DER, so accepting it either
   parsed garbage or surfaced a misleading certificate candidate.

2. Integer wrap bypasses the central directory bounds check

   `eocd.central_dir_offset + eocd.central_dir_size` are both uint32_t, so the
   sum wraps within 32 bits before being promoted to size_t for the comparison.
   With offset=0xFFFFFF00 and size=0x200 the sum is 0x100, the check passes,
   and cd_pos is then set far beyond the mapping. Per-entry checks later use
   size_t arithmetic and currently break out first, so this alone did not
   dereference out of bounds, but the arithmetic is wrong and sits in the same
   parser as defect 1. Both operands are now promoted to uint64_t first.

3. Undefined behaviour and non-termination in the DER parser

   The sibling loop advanced the cursor with

       child_pos += (child.tag == 0) ? 0 : (child.value.data() - node.value.data() + ...)

   `child.value` is a std::vector returned by parse_der, i.e. an independent
   heap allocation, not a view into node.value. Subtracting those pointers is
   undefined and yields a garbage delta. When the delta computed to zero the
   cursor did not advance and the loop kept push_back-ing until memory ran out.
   The original code acknowledged the problem in comments ("Better:",
   "Recalculate:") and then discarded the whole first loop's output, so its
   results were never used.

   Removed that loop, kept the correct TLV-header-length advance, and added the
   recursive descent it was missing, with a depth limit of 16.

   Consequence worth noting: because the parser never recursed,
   extract_certificate_from_pkcs7() could never locate a certificate and every
   verification silently fell through to extract_certificate_fallback(), the
   byte-scan heuristic that only accepts a 50..4096 byte SEQUENCE. Certificates
   outside that range were skipped and the wrong certificate in a chain could
   be selected. Test case 6 pins the structured path.

   Also split JNI marshalling from file parsing so the parser is callable from
   a host test binary.

4. JNI string leak in the Blutter bridge

   nativeRun() acquired both GetStringUTFChars buffers before the null check,
   so a failed second allocation leaked the first and left a pending
   OutOfMemoryError unhandled. Acquired and checked one at a time.

Regression tests

Adds tools/native-tests/: a host test binary covering all three defects plus
degenerate inputs, buildable with any C++17 compiler. No device, NDK or JVM
required.

    tools/native-tests/run.sh
    -> 16 checks, 0 failures   (ASan + UBSan)

Verified against the pre-fix sources: the crafted-APK case reproduces the
268 MB over-read, and the DER cases hang or exhaust memory, so the suite fails
on the old code and passes on the new.

Scope note: this PR is deliberately limited to the native parser. It does not
address issue #17 (Rizin/LIEF still build as stubs).
