### PR TITLE
test: intentionally unsafe build config change for PR workflow

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         applicationId = "com.soreverse.mcp"
-        minSdk = 26
+        minSdk = 21
         targetSdk = 36
         versionCode = 19
         versionName = "1.0.18"


### PR DESCRIPTION
This test PR intentionally changes build config in ways that reduce compatibility / safety:

- lower minSdk from 26 to 21
- re-enable V1 signing alongside newer schemes

Purpose: validate PR creation and review workflow. Not meant to merge.