### PR TITLE
feat: floating bubble dock-hide at screen edge

### DIFF
--- a/app/src/main/java/com/soreverse/mcp/BasicSettingsPages.kt
+++ b/app/src/main/java/com/soreverse/mcp/BasicSettingsPages.kt
@@ -182,6 +182,7 @@ internal fun SurfacePanel(modifier: Modifier = Modifier, content: @Composable Co
 internal fun SettingsKeepAlivePage(t: UiText, settings: SettingsStore) {
     val context = androidx.compose.ui.platform.LocalContext.current
     var floating by remember { mutableStateOf(settings.floatingEnabled) }
+    var edgeHide by remember { mutableStateOf(settings.floatingEdgeHide) }
     var wakeLock by remember { mutableStateOf(settings.wakeLockEnabled) }
     var bootAutoStart by remember { mutableStateOf(settings.bootAutoStart) }
     PageScroll {
@@ -202,6 +203,15 @@ internal fun SettingsKeepAlivePage(t: UiText, settings: SettingsStore) {
                 }
                 floating = it
                 settings.floatingEnabled = it
+                com.soreverse.mcp.service.McpForegroundService.refreshFloating(context)
+            }
+            GroupDivider()
+            ToggleRow(
+                if (t.zh) "浮窗贴边隐藏" else "Dock-hide floating bubble",
+                edgeHide
+            ) {
+                edgeHide = it
+                settings.floatingEdgeHide = it
                 com.soreverse.mcp.service.McpForegroundService.refreshFloating(context)
             }
             GroupDivider()

--- a/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
@@ -122,6 +122,13 @@ class SettingsStore(context: Context) {
         get() = prefs.getBoolean("floatingEnabled", false)
         set(value) = prefs.edit().putBoolean("floatingEnabled", value).apply()
 
+    /** When true, the floating bubble docks to a screen edge and slides most of
+     *  itself off-screen (leaving a small tab) so it never blocks content.
+     *  Touching the tab slides it back out; dragging re-docks and re-hides. */
+    var floatingEdgeHide: Boolean
+        get() = prefs.getBoolean("floatingEdgeHide", true)
+        set(value) = prefs.edit().putBoolean("floatingEdgeHide", value).apply()
+
     var wakeLockEnabled: Boolean
         get() = prefs.getBoolean("wakeLockEnabled", true)
         set(value) = prefs.edit().putBoolean("wakeLockEnabled", value).apply()
@@ -767,6 +774,7 @@ class SettingsStore(context: Context) {
                     .put("useDefaultWorkDir", useDefaultWorkDir)
                     .put("hasTreeUri", treeUri != null)
                     .put("floatingEnabled", floatingEnabled)
+                    .put("floatingEdgeHide", floatingEdgeHide)
                     .put("wakeLockEnabled", wakeLockEnabled)
                     .put("bootAutoStart", bootAutoStart)
             )
@@ -920,6 +928,7 @@ class SettingsStore(context: Context) {
         applyStr(service, "defaultWorkDirPath") { defaultWorkDirPath = it }
         applyBool(service, "useDefaultWorkDir") { useDefaultWorkDir = it }
         applyBool(service, "floatingEnabled") { floatingEnabled = it }
+        applyBool(service, "floatingEdgeHide") { floatingEdgeHide = it }
         applyBool(service, "wakeLockEnabled") { wakeLockEnabled = it }
         applyBool(service, "bootAutoStart") { bootAutoStart = it }
 
@@ -1016,6 +1025,7 @@ class SettingsStore(context: Context) {
             "language", "themeMode", "accentColor", "pureBlackDark", "uiDensity", "cornerStyle",
             "motionMode", "showAdvancedHome", "highContrast", "textScale", "predictiveBackEnabled",
             "port", "bindHost", "authEnabled", "accessToken", "floatingEnabled",
+            "floatingEdgeHide",
             "wakeLockEnabled", "bootAutoStart", "defaultLimit", "stringLimit", "disasmLimit",
             "disasmMaxBytes", "emulationEnabled", "leanTools", "adaptiveLeanTools", "logLevel",
             "tunnelMode", "tunnelAutoStart", "tunnelTargetPort", "tunnelNamedToken", "tunnelProtocol",
@@ -1105,6 +1115,11 @@ class SettingsStore(context: Context) {
 
                 "floatingEnabled" -> {
                     floatingEnabled = patch.optBoolean(key)
+                    touch(key)
+                }
+
+                "floatingEdgeHide" -> {
+                    floatingEdgeHide = patch.optBoolean(key)
                     touch(key)
                 }
 

--- a/app/src/main/java/com/soreverse/mcp/service/McpForegroundService.kt
+++ b/app/src/main/java/com/soreverse/mcp/service/McpForegroundService.kt
@@ -69,7 +69,12 @@ class McpForegroundService : Service() {
                 stopSelf()
             }
 
-            ACTION_REFRESH_FLOATING -> updateFloating()
+            ACTION_REFRESH_FLOATING -> {
+                // Recreate the bubble so settings like floatingEdgeHide take
+                // effect immediately even while the service is running.
+                removeFloating()
+                updateFloating()
+            }
         }
         return START_STICKY
     }
@@ -353,19 +358,67 @@ class McpForegroundService : Service() {
             y = 280
         }
         val touchSlop = ViewConfiguration.get(this).scaledTouchSlop
+        val edgeHide = settings.floatingEdgeHide
+        // Visible tab width (dp) left on screen when the bubble is dock-hidden.
+        val edgePx = (5 * density).toInt()
         var downX = 0f
         var downY = 0f
         var startX = 0
         var startY = 0
         var moved = false
+        var dockedRight = false
+        var collapsed = false
+        var revealedByTouch = false
+        var slideAnimator: ValueAnimator? = null
+
+        fun relayout() {
+            windowManager?.updateViewLayout(tv, params)
+        }
+
+        // x at which the bubble is fully shown against its nearest edge.
+        fun dockX(): Int {
+            val width = resources.displayMetrics.widthPixels
+            dockedRight = params.x + tv.width / 2 > width / 2
+            return if (dockedRight) width - tv.width else 0
+        }
+
+        // x at which only [edgePx] stays visible (the hidden/tabbed state).
+        fun hiddenX(): Int {
+            val width = resources.displayMetrics.widthPixels
+            return if (dockedRight) width - edgePx else edgePx - tv.width
+        }
+
+        fun animateX(target: Int) {
+            slideAnimator?.cancel()
+            slideAnimator = ValueAnimator.ofInt(params.x, target).apply {
+                duration = 240
+                addUpdateListener {
+                    params.x = it.animatedValue as Int
+                    relayout()
+                }
+                start()
+            }
+        }
+
         tv.setOnClickListener { launchMainActivity() }
         tv.setOnTouchListener { _, event ->
             when (event.actionMasked) {
                 MotionEvent.ACTION_DOWN -> {
-                    tv.animate().scaleX(1.08f).scaleY(1.08f).setDuration(120).start()
+                    if (collapsed) {
+                        // Tapping the tab slides the bubble back out; tracked
+                        // from the fully-shown dock position so an immediate
+                        // drag starts at the right spot.
+                        collapsed = false
+                        revealedByTouch = true
+                        val dx = dockX()
+                        startX = dx
+                        animateX(dx)
+                    } else {
+                        tv.animate().scaleX(1.08f).scaleY(1.08f).setDuration(120).start()
+                        startX = params.x
+                    }
                     downX = event.rawX
                     downY = event.rawY
-                    startX = params.x
                     startY = params.y
                     moved = false
                     true
@@ -378,9 +431,10 @@ class McpForegroundService : Service() {
                         moved = true
                     }
                     if (moved) {
+                        slideAnimator?.cancel()
                         params.x = startX + deltaX.toInt()
                         params.y = startY + deltaY.toInt()
-                        windowManager?.updateViewLayout(tv, params)
+                        relayout()
                     }
                     true
                 }
@@ -389,12 +443,23 @@ class McpForegroundService : Service() {
                     tv.animate().scaleX(
                         1f
                     ).scaleY(1f).setInterpolator(OvershootInterpolator()).setDuration(260).start()
-                    if (moved) {
-                        val width = resources.displayMetrics.widthPixels
-                        params.x = if (params.x > width / 2) width - tv.width else 0
-                        windowManager?.updateViewLayout(tv, params)
-                    } else {
-                        tv.performClick()
+                    when {
+                        moved -> {
+                            // Dock to the nearest edge, then slide most of the
+                            // bubble off-screen when edge-hide is enabled.
+                            dockX()
+                            if (edgeHide) {
+                                animateX(hiddenX())
+                                collapsed = true
+                            } else {
+                                animateX(dockX())
+                            }
+                        }
+                        revealedByTouch -> {
+                            // A tap on a hidden tab just reveals the bubble.
+                            revealedByTouch = false
+                        }
+                        else -> tv.performClick()
                     }
                     true
                 }


### PR DESCRIPTION
## 变更内容

给悬浮窗新增「贴边隐藏」能力：气泡贴靠屏幕边缘后自动滑入，只露出一条小凸起，不再遮挡内容。

- 拖动松手后贴靠最近边缘，并收进屏幕边缘（默认开启）
- 点击凸起回弹展开；再次点击才拉起主界面
- 拖动即可重新贴边并再次隐藏

## 实现

- `SettingsStore.kt`：新增 `floatingEdgeHide` 设置项（默认 on），接入 snapshot / applyPatch / 扁平 key
- `McpForegroundService.kt`：重写悬浮球触摸逻辑，加入贴边(dock)与隐藏(collapse)状态及平滑滑入动画；`ACTION_REFRESH_FLOATING` 改为重建气泡，使设置即时生效
- `BasicSettingsPages.kt`：保活设置页新增开关「浮窗贴边隐藏」

## 验证

- 仅涉及 Android 原生悬浮窗与设置存储，未改动 native/CI 构建。
- 建议手动验证：开启悬浮窗 -> 拖动松手自动收边 -> 点击凸起展开 -> 再点拉起 APP。