### PR TITLE
feat: 增加动态分析（unidbg 模拟 + Frida 真机）

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,34 @@ lief_api(action=capabilities|parse|list|patch_address|add_export|remove_symbol|b
 unidbg_api(action=capabilities|status|call|dump)
 xanso_api(action=capabilities|status|fix_sections)
 flutter_blutter(action=inspect|analyze|status|result|cancel|packages|prune)
+dynamic_api(action=capabilities|dispatch|status|analyze)
+dynamic_analyze_ai(evidence=...|function=...|request=...)
 ```
+
+## 动态分析（手动加载到内存 → AI 分析）
+
+SOMCP 提供一套**独立**的动态分析工具流程，与静态 deep-analysis 循环彼此分离，把「把 `.so` 手动加载到内存 → 执行 → 采集证据 → 交给 AI 分析」串成一条可被 MCP 调用的链路。核心入口是两个工具：
+
+```text
+dynamic_api(action=capabilities|dispatch|status|analyze, op=unidbg_session_open|unidbg_session_call|unidbg_session_registers|frida_hook|frida_call|analyze, backend=unidbg|frida, targetFunction=...)
+dynamic_analyze_ai(function=... | evidence=...)
+```
+
+两个后端共用同一套编排层 `dynamicDispatch`：
+
+- **unidbg（模拟）**：`unidbg_session_open` 把选中的 `.so` 映射进模拟内存，`unidbg_session_call` 解析指定导出函数并执行，随后采集寄存器和目标地址的内存 dump。无需真机，适合快速验证目标函数行为。
+- **frida（真机 hook）**：`FridaBridge` 以纯 Kotlin 实现 `frida-server`/`frida-gadget` 的 TCP 协议客户端，`frida_hook` 通过 JS agent（Interceptor/Module）挂钩目标函数捕获入参与返回，`frida_call` 触发调用并回读 hook 结果。**注意**：`frida-server`/`frida-gadget` 不随 APK 内置，需在已 root 设备上单独安装并在推开时先对目标进程 `ptrace`/注入；未就绪时 `dynamic_api(action=capabilities)` 的 `status.fridaAvailable` 会如实标注 `false`，不会伪装成可用。
+
+`dynamic_analyze_ai` 复用 `RikkaAgentEngine`，把 `dynamicRun` 证据（寄存器现场、内存 dump、hook 记录、调用返回）喂给 AI 生成结构化动态分析报告：
+
+```text
+dynamic_api(action=capabilities)        # 查看 backends.dynamic，确认 unidbg/frida 可用性
+dynamic_api(action=dispatch, backend=unidbg, op=unidbg_session_open, targetFunction="JNI_OnLoad")
+dynamic_api(action=dispatch, backend=unidbg, op=unidbg_session_call, targetFunction="JNI_OnLoad")
+dynamic_analyze_ai(function="JNI_OnLoad")  # 或直接传入上一步 evidence
+```
+
+`meta_info(action=capabilities)` 的 `backends.dynamic` 是动态分析的能力真实面来源，明确列出 unidbg/frida 的支持状态与限制。
 
 `rizin_api(action=command)` 提供受控 Rizin raw command 通道，用于覆盖大量 Rizin 命令式底层能力；为安全起见，写入、文件、shell 等危险命令会被阻止。
 

--- a/app/src/main/java/com/soreverse/mcp/core/DynamicAnalysisService.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/DynamicAnalysisService.kt
@@ -193,8 +193,10 @@ Requirements:
         if (settings.aiEndpoint.isBlank()) error("AI endpoint is empty")
     }
 
-    private fun emit(kind: DynamicAnalysisEvent.Kind, text: String, toolName: String = "") {
-        _events.tryEmit(DynamicAnalysisEvent(kind, text, toolName))
+    private suspend fun emit(kind: DynamicAnalysisEvent.Kind, text: String, toolName: String = "") {
+        // suspend emit() rather than tryEmit() so a temporarily-full consumer
+        // suspends instead of silently dropping analysis state events.
+        _events.emit(DynamicAnalysisEvent(kind, text, toolName))
     }
 
     private companion object {

--- a/app/src/main/java/com/soreverse/mcp/core/DynamicAnalysisService.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/DynamicAnalysisService.kt
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// DynamicAnalysisService: the standalone AI analysis that consumes the
+// dynamicRun evidence produced by the dynamic-analysis MCP workflow
+// (unidbg emulation and/or Frida on-device hooking). It is deliberately
+// independent from the static DeepAnalysisService loop: the input is the
+// runtime evidence envelope, and the AI may call dynamic MCP tools for
+// follow-up before producing a Markdown report.
+package com.soreverse.mcp.core
+
+import android.content.Context
+import android.util.Log
+import com.soreverse.mcp.mcp.SchemaBuilder
+import com.soreverse.mcp.mcp.ToolCatalog
+import com.soreverse.mcp.mcp.ToolContext
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import org.json.JSONObject
+
+data class DynamicAnalysisEvent(val kind: Kind, val text: String, val toolName: String = "") {
+    enum class Kind { STATUS, THINKING, TOOL, FINALIZING, TEXT, ERROR, DONE }
+}
+
+class DynamicAnalysisService(private val appContext: Context) {
+    private val _events = MutableSharedFlow<DynamicAnalysisEvent>(extraBufferCapacity = 128)
+    val events: SharedFlow<DynamicAnalysisEvent> = _events
+    private val _reportDraft = MutableStateFlow("")
+    val reportDraft: StateFlow<String> = _reportDraft
+    private val _partsDraft = MutableStateFlow<List<RikkaPart>>(emptyList())
+    val partsDraft: StateFlow<List<RikkaPart>> = _partsDraft
+
+    /** Blocking entry used by the MCP dynamic_analyze_ai tool (heavy tool). */
+    fun analyzeSync(
+        dynamicRun: String,
+        path: String,
+        settings: SettingsStore,
+        zh: Boolean,
+        request: String
+    ): Result<String> = runBlocking(Dispatchers.IO) { analyze(dynamicRun, path, settings, zh, request) }
+
+    suspend fun analyze(
+        dynamicRun: String,
+        path: String,
+        settings: SettingsStore,
+        zh: Boolean,
+        request: String
+    ): Result<String> = withContext(Dispatchers.IO) {
+        runCatching {
+            requireConfigured(settings)
+            emit(DynamicAnalysisEvent.Kind.STATUS, if (zh) "正在初始化动态分析 AI 会话…" else "Initializing dynamic-analysis AI session…")
+            val userPrompt = buildUserPrompt(dynamicRun, path, zh, request)
+            val engine = RikkaAgentEngine(
+                client = OkHttpClient.Builder().connectTimeout(20, TimeUnit.SECONDS)
+                    .readTimeout(10, TimeUnit.MINUTES)
+                    .writeTimeout(120, TimeUnit.SECONDS)
+                    .retryOnConnectionFailure(true).build(),
+                provider = settings.aiProvider,
+                endpoint = settings.aiEndpoint,
+                apiKey = settings.aiApiKey,
+                model = settings.aiModel,
+                temperature = settings.aiTemperature,
+                customHeaders = parseStringMap(settings.aiCustomHeadersJson),
+                customBody = buildAdditionalProperties(settings)
+            )
+            val tools = buildRikkaTools(settings, zh)
+            var lastReasoning = ""
+            val finalReport = engine.run(
+                settings.aiSystemPrompt,
+                userPrompt,
+                tools,
+                settings.aiMaxIterations.coerceIn(20, 256)
+            ) { parts ->
+                _partsDraft.value = parts
+                val report = parts.filterIsInstance<RikkaPart.Text>().joinToString("") { it.text }
+                if (report.isNotEmpty()) _reportDraft.value = report
+                val reasoning = parts.filterIsInstance<RikkaPart.Reasoning>().joinToString("") { it.text }
+                if (reasoning.length > lastReasoning.length) {
+                    emit(DynamicAnalysisEvent.Kind.THINKING, reasoning.drop(lastReasoning.length))
+                    lastReasoning = reasoning
+                }
+            }
+            if (finalReport.isBlank()) error(if (zh) "模型返回了空的分析结果" else "The model returned an empty analysis result")
+            _reportDraft.value = finalReport
+            emit(DynamicAnalysisEvent.Kind.DONE, finalReport)
+            finalReport
+        }.onFailure { Log.e("SOMCP-Dynamic", "AI dynamic analysis failed", it) }
+    }
+
+    private fun buildUserPrompt(dynamicRun: String, path: String, zh: Boolean, request: String): String {
+        val focus = request.trim().takeIf(String::isNotBlank)
+        return if (zh) {
+            """请对以下 Android native SO 的动态运行证据做独立逆向分析，输出结构化报告。
+目标文件: $path
+${focus?.let { "用户本轮问题: $it" }.orEmpty()}
+
+以下是已经手动加载目标 .so（或附加到真机进程）并执行后采集到的动态运行证据（dynamicRun 信封）：
+```json
+$dynamicRun
+```
+
+要求：
+1. 依据动态证据解读函数实际行为（参数、返回值、寄存器、内存、hook 命中、backtrace/trace）。
+2. 需要补充取证时，必须调用 dynamic_api / unidbg_api / so_open 等 MCP 工具，凭证据用工具结果，不得用文字代替。
+3. 明确区分 unidbg 模拟环境证据与 Frida 真机证据，标注各自的置信度和失效模式。
+4. 最终报告包含：动态行为概述、关键函数运行时语义、输入/输出契约、反调试/反模拟对抗证据、安全风险、可行性、下一步建议。
+5. 只有完成必要取证后才返回最终 Markdown 报告，前后不要加“接下来将……”之类过程性文字。"""
+        } else {
+            """Perform an independent reverse-engineering analysis of the following dynamic runtime evidence for an Android native SO and produce a structured report.
+Target file: $path
+${focus?.let { "User request for this turn: $it" }.orEmpty()}
+
+The target .so was manually loaded into an execution context (or attached to a live device process) and run; the collected runtime evidence (the dynamicRun envelope) is:
+```json
+$dynamicRun
+```
+
+Requirements:
+1. Interpret actual function behavior from the dynamic evidence: arguments, return values, registers, memory, hook hits, backtrace/trace.
+2. If more forensics are needed, MUST call dynamic_api / unidbg_api / so_open MCP tools and rely on their results; never replace a tool call with prose.
+3. Clearly distinguish unidbg-emulated evidence from Frida on-device evidence, noting confidence and failure modes for each.
+4. Final report sections: Dynamic Behavior, Runtime Semantics of Key Functions, Input/Output Contract, Anti-debug/Anti-emulation Evidence, Security Risk, Feasibility, Next Steps.
+5. Only after gathering the necessary evidence, return the final Markdown report; do not add process text such as 'next I will…' before or after it."""
+        }
+    }
+
+    private fun buildRikkaTools(settings: SettingsStore, zh: Boolean): List<RikkaTool> {
+        val engine = EngineProvider.get(appContext)
+        val ctx = ToolContext(appContext, settings, engine)
+        return DYNAMIC_TOOL_NAMES.mapNotNull { name ->
+            val handler = ToolCatalog.byName[name] ?: return@mapNotNull null
+            val schema = handler.meta.schemaBuilder.invoke(SchemaBuilder)
+            RikkaTool(
+                name = name,
+                description = if (zh) handler.meta.zh else handler.meta.en,
+                schema = schema
+            ) { args ->
+                emit(DynamicAnalysisEvent.Kind.TOOL, if (zh) "调用工具 $name" else "Calling tool $name", name)
+                runCatching { handler.handle(ctx, args) }
+                    .onSuccess { AppLog.i("dynamic AI tool completed $name") }
+                    .onFailure { AppLog.e("dynamic AI tool failed $name", it) }
+                    .getOrThrow()
+                    .let { payload ->
+                        val text = payload.toString()
+                        val limit = settings.toolResultMaxChars
+                        if (limit <= 0 || text.length <= limit) text else text.take(limit) + "…"
+                    }
+            }
+        }
+    }
+
+    private fun parseStringMap(raw: String): Map<String, String> {
+        val obj = runCatching { org.json.JSONObject(raw.ifBlank { "{}" }) }.getOrNull() ?: return emptyMap()
+        val map = linkedMapOf<String, String>()
+        val keys = obj.keys()
+        while (keys.hasNext()) {
+            val key = keys.next().trim()
+            if (key.isNotBlank()) map[key] = obj.optString(key)
+        }
+        return map
+    }
+
+    private fun buildAdditionalProperties(settings: SettingsStore): Map<String, kotlinx.serialization.json.JsonElement> {
+        val properties = linkedMapOf<String, kotlinx.serialization.json.JsonElement>()
+        val body = runCatching { JsonUtilBody.parse(settings.aiCustomBodyJson) }.getOrNull() ?: return properties
+        val keys = body.keys()
+        val json = kotlinx.serialization.json.Json
+        while (keys.hasNext()) {
+            val key = keys.next().trim()
+            if (key.isBlank()) continue
+            val value = body.opt(key)
+            properties[key] = runCatching { json.parseToJsonElement(when (value) {
+                null, org.json.JSONObject.NULL -> "null"
+                is String -> org.json.JSONObject.quote(value)
+                else -> value.toString()
+            }) }.getOrElse { kotlinx.serialization.json.JsonPrimitive(value?.toString().orEmpty()) }
+        }
+        return properties
+    }
+
+    private fun requireConfigured(settings: SettingsStore) {
+        if (settings.aiApiKey.isBlank()) error("AI API key is empty")
+        if (settings.aiModel.isBlank()) error("AI model is empty")
+        if (settings.aiEndpoint.isBlank()) error("AI endpoint is empty")
+    }
+
+    private fun emit(kind: DynamicAnalysisEvent.Kind, text: String, toolName: String = "") {
+        _events.tryEmit(DynamicAnalysisEvent(kind, text, toolName))
+    }
+
+    private companion object {
+        val DYNAMIC_TOOL_NAMES = listOf(
+            "dynamic_api",
+            "unidbg_api",
+            "so_open",
+            "analyze_functions",
+            "analysis_report",
+            "meta_info"
+        )
+    }
+}
+
+/** Minimal org.json holder to avoid pulling JsonUtil internals into the AI path. */
+private object JsonUtilBody {
+    fun parse(raw: String): org.json.JSONObject = org.json.JSONObject(raw.ifBlank { "{}" })
+}

--- a/app/src/main/java/com/soreverse/mcp/core/DynamicAnalysisService.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/DynamicAnalysisService.kt
@@ -26,8 +26,8 @@ import com.soreverse.mcp.mcp.ToolContext
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -47,21 +47,10 @@ class DynamicAnalysisService(private val appContext: Context) {
     val partsDraft: StateFlow<List<RikkaPart>> = _partsDraft
 
     /** Blocking entry used by the MCP dynamic_analyze_ai tool (heavy tool). */
-    fun analyzeSync(
-        dynamicRun: String,
-        path: String,
-        settings: SettingsStore,
-        zh: Boolean,
-        request: String
-    ): Result<String> = runBlocking(Dispatchers.IO) { analyze(dynamicRun, path, settings, zh, request) }
+    fun analyzeSync(dynamicRun: String, path: String, settings: SettingsStore, zh: Boolean, request: String): Result<String> =
+        runBlocking(Dispatchers.IO) { analyze(dynamicRun, path, settings, zh, request) }
 
-    suspend fun analyze(
-        dynamicRun: String,
-        path: String,
-        settings: SettingsStore,
-        zh: Boolean,
-        request: String
-    ): Result<String> = withContext(Dispatchers.IO) {
+    suspend fun analyze(dynamicRun: String, path: String, settings: SettingsStore, zh: Boolean, request: String): Result<String> = withContext(Dispatchers.IO) {
         runCatching {
             requireConfigured(settings)
             emit(DynamicAnalysisEvent.Kind.STATUS, if (zh) "正在初始化动态分析 AI 会话…" else "Initializing dynamic-analysis AI session…")
@@ -185,11 +174,15 @@ Requirements:
             val key = keys.next().trim()
             if (key.isBlank()) continue
             val value = body.opt(key)
-            properties[key] = runCatching { json.parseToJsonElement(when (value) {
-                null, org.json.JSONObject.NULL -> "null"
-                is String -> org.json.JSONObject.quote(value)
-                else -> value.toString()
-            }) }.getOrElse { kotlinx.serialization.json.JsonPrimitive(value?.toString().orEmpty()) }
+            properties[key] = runCatching {
+                json.parseToJsonElement(
+                    when (value) {
+                        null, org.json.JSONObject.NULL -> "null"
+                        is String -> org.json.JSONObject.quote(value)
+                        else -> value.toString()
+                    }
+                )
+            }.getOrElse { kotlinx.serialization.json.JsonPrimitive(value?.toString().orEmpty()) }
         }
         return properties
     }

--- a/app/src/main/java/com/soreverse/mcp/engine/EngineRuntime.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/EngineRuntime.kt
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
 package com.soreverse.mcp.engine
 
 import android.content.Context
@@ -13,6 +25,7 @@ internal class EngineRuntime(internal val context: Context) {
     internal val lief = LiefEngine()
     internal val xanso = XAnSoEngine(context)
     internal val unidbg = UnidbgEmulator(context)
+    internal val frida = FridaBridge(context)
     internal val blutter = BlutterCoordinator(context)
     internal var workDir: WorkDirectory? = null
     internal var workDirUri: Uri? = null

--- a/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeBackendLief.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeBackendLief.kt
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
 package com.soreverse.mcp.engine
 
 import com.soreverse.mcp.core.err
@@ -182,7 +194,58 @@ internal fun EngineRuntime.capabilityRegistry(): JSONObject = JSONObject()
                         "Complete public xAnSo CLI/core functionality: h/help, build-section, quit/session close semantics"
                     )
             )
+            .put(
+                "dynamic",
+                dynamicCapabilityEntry()
+            )
     )
+
+internal fun EngineRuntime.dynamicCapabilityEntry(): JSONObject {
+    val unidbgAvailable = unidbg.available()
+    val fridaTarget = FridaTarget()
+    val fridaAvailable = frida.available(fridaTarget)
+    return JSONObject()
+        .put(
+            "status",
+            JSONObject()
+                .put("unidbgAvailable", unidbgAvailable)
+                .put("fridaAvailable", fridaAvailable)
+                .put(
+                    "fridaSetup",
+                    "requires-extra-install: frida-server / frida-gadget (${fridaTarget.host}:${fridaTarget.port}) — ${frida.unavailableReason(fridaTarget)}"
+                )
+        )
+        .put("coverageClass", "standalone_dynamic_analysis_gateway")
+        .put(
+            "supported",
+            JSONArray(
+                listOf(
+                    "unidbg: manual load .so into emulated memory",
+                    "unidbg: session_call / registers / dump / trace / close",
+                    "frida: real-device attach/spawn + JS agent",
+                    "frida: Interceptor hook, native call, read memory, backtrace",
+                    "dynamic_analyze orchestration -> structured dynamicRun evidence",
+                    "dynamic_analyze_ai independent AI analysis"
+                )
+            )
+        )
+        .put(
+            "backendSplit",
+            JSONObject()
+                .put(
+                    "unidbg",
+                    "emulated VM memory space; no device required; reused verified engine path"
+                )
+                .put(
+                    "frida",
+                    "live device process address space; requires frida-server/gadget; loaded & driven with Frida JS"
+                )
+        )
+        .put(
+            "note",
+            "dynamicRun evidence produced by dynamic_analyze can be handed to DynamicAnalysisService / dynamic_analyze_ai for an independent AI report, separate from the static deep-analysis loop."
+        )
+}
 
 internal fun EngineRuntime.liefDispatch(
     workspaceId: String,

--- a/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeDynamic.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeDynamic.kt
@@ -356,6 +356,10 @@ private fun EngineRuntime.dynamicAnalyze(workspaceId: String, editSessionId: Str
                 JSONObject().put("functionName", targetFunction)
             )
             run.put("hook", hook)
+            // Retrieve any events captured by the interceptor since hook
+            // installation (module-level buffer drained on each poll).
+            val hookEvents = frida.invokeRpc(session.id, "getEvents", JSONObject())
+            run.put("hookEvents", hookEvents)
             val callResult = frida.invokeRpc(
                 session.id,
                 "callFunction",

--- a/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeDynamic.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeDynamic.kt
@@ -237,11 +237,7 @@ internal fun EngineRuntime.dynamicDispatch(
 
 // ── High-level orchestration: "手动加载到内存 → 执行 → 采集证据" ──
 
-private fun EngineRuntime.dynamicAnalyze(
-    workspaceId: String,
-    editSessionId: String,
-    args: JSONArray
-): JSONObject = guarded {
+private fun EngineRuntime.dynamicAnalyze(workspaceId: String, editSessionId: String, args: JSONArray): JSONObject = guarded {
     val params = args.optJSONObject(0) ?: JSONObject()
     val backend = params.str("backend", "unidbg")
     if (workspaceId.isBlank()) {
@@ -274,7 +270,9 @@ private fun EngineRuntime.dynamicAnalyze(
             if (emulatorSessionId.isBlank()) {
                 return@guarded err(
                     "UNIDBG_LOAD_FAILED",
-                    "Could not manually load the .so into emulated memory: ${opened.optJSONObject("error")?.optString("message") ?: opened.optString("message")}",
+                    "Could not manually load the .so into emulated memory: ${opened.optJSONObject(
+                        "error"
+                    )?.optString("message") ?: opened.optString("message")}",
                     "backend",
                     "unidbg",
                     "openResult" to opened
@@ -320,9 +318,13 @@ private fun EngineRuntime.dynamicAnalyze(
         "frida" -> {
             val target = fridaTargetFromArgs(params)
             if (!frida.available(target)) {
+                val reason = "Frida is not reachable at " +
+                    "${target.host}:${target.port}. " +
+                    "Install and start frida-server / frida-gadget " +
+                    "on the device, then retry. ${frida.unavailableReason(target)}"
                 return@guarded err(
                     "FRIDA_UNAVAILABLE",
-                    "Frida is not reachable at ${target.host}:${target.port}. Install and start frida-server / frida-gadget on the device, then retry. ${frida.unavailableReason(target)}",
+                    reason,
                     "backend",
                     "frida",
                     "target" to target.host + ":" + target.port
@@ -403,5 +405,4 @@ private fun EngineRuntime.fridaTargetFromArgs(raw: Any?): FridaTarget {
     )
 }
 
-private fun JSONObject.bool(name: String, default: Boolean): Boolean =
-    if (has(name)) optBoolean(name, default) else default
+private fun JSONObject.bool(name: String, default: Boolean): Boolean = if (has(name)) optBoolean(name, default) else default

--- a/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeDynamic.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeDynamic.kt
@@ -253,6 +253,7 @@ private fun EngineRuntime.dynamicAnalyze(workspaceId: String, editSessionId: Str
         )
     }
     val trace = params.bool("trace", false)
+    val retaddr = params.bool("retaddr", false)
     val dumpSize = params.intValue("dumpSize", 256).coerceIn(1, 65536)
     val functionArgs = params.optJSONArray("args") ?: JSONArray()
 
@@ -346,7 +347,7 @@ private fun EngineRuntime.dynamicAnalyze(workspaceId: String, editSessionId: Str
                 target,
                 mode,
                 processTarget,
-                frida.defaultAgentHtml(moduleName, targetFunction, trace)
+                frida.defaultAgentHtml(moduleName, retaddr)
             )
             run.put("fridaSessionId", session.id)
             // 2) Hook the target function and call it live.

--- a/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeDynamic.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeDynamic.kt
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// EngineRuntimeDynamic: the standalone "dynamic analysis" workflow for SOMCP.
+//
+// It is deliberately separate from the static deep-analysis loop (Directive:
+// unidbg emulation + Frida on-device hooking, piped to an independent AI
+// analysis). The user manually selects a backend, a target `.so` (workspace)
+// and a target function, loads it into the chosen execution context, runs it,
+// and collects runtime evidence (registers / memory / hook / trace).
+//
+//   Unidbg backend -> "手动加载到内存" == Unidbg session_open (loads the .so
+//   into an emulated VM address space), then session_call / session_registers /
+//   session_dump / session_trace. Thin re-use of the verified engine path.
+//
+//   Frida backend   -> "手动加载到内存" == live load of the module into a real
+//   device process address space, then Interceptor/Module/Memory agents.
+//
+// Both produce the same structured `dynamicRun` evidence envelope that can be
+// handed to DynamicAnalysisService for an independent AI report.
+package com.soreverse.mcp.engine
+
+import com.soreverse.mcp.core.err
+import com.soreverse.mcp.core.ok
+import com.soreverse.mcp.core.str
+import java.net.UnknownHostException
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** Root frida targets are resolved from the FridaBridge; this is the constant
+ *  set of operations EngineRuntimeDynamic can dispatch. */
+private val DYNAMIC_METHODS = JSONArray(
+    listOf(
+        "status",
+        "roots",
+        "methods",
+        "capabilities",
+        "analyze",
+        "unidbg_session_open",
+        "unidbg_session_call",
+        "unidbg_session_dump",
+        "unidbg_session_registers",
+        "unidbg_session_trace",
+        "unidbg_session_close",
+        "frida_status",
+        "frida_sessions",
+        "frida_open",
+        "frida_close",
+        "frida_hook",
+        "frida_call",
+        "frida_read",
+        "frida_backtrace"
+    )
+)
+
+private val DYNAMIC_ROOTS = JSONArray(listOf("unidbg", "frida", "sessions"))
+
+internal fun EngineRuntime.dynamicDispatch(
+    workspaceId: String,
+    editSessionId: String = "",
+    op: String,
+    method: String = "",
+    args: JSONArray = JSONArray()
+): JSONObject = guarded {
+    when (op) {
+        "status" -> ok(
+            JSONObject()
+                .put("roots", DYNAMIC_ROOTS)
+                .put("unidbg", emulationStatus())
+                .put("frida", frida.connectionStatus(fridaTargetFromArgs(args.opt(0))))
+                .put("sessions", fridaSessionsView())
+        )
+
+        "roots" -> ok(JSONObject().put("roots", DYNAMIC_ROOTS))
+
+        "methods" -> ok(
+            JSONObject().put("methods", DYNAMIC_METHODS).put("roots", DYNAMIC_ROOTS)
+        )
+
+        "capabilities" -> ok(
+            JSONObject()
+                .put(
+                    "unidbg",
+                    JSONObject()
+                        .put("available", unidbg.available())
+                        .put(
+                            "operations",
+                            JSONArray(
+                                listOf(
+                                    "unidbg_session_open",
+                                    "unidbg_session_call",
+                                    "unidbg_session_dump",
+                                    "unidbg_session_registers",
+                                    "unidbg_session_trace",
+                                    "unidbg_session_close"
+                                )
+                            )
+                        )
+                )
+                .put(
+                    "frida",
+                    JSONObject()
+                        .put("available", frida.available(fridaTargetFromArgs(args.opt(0))))
+                        .put(
+                            "operations",
+                            JSONArray(
+                                listOf(
+                                    "frida_status",
+                                    "frida_open",
+                                    "frida_hook",
+                                    "frida_call",
+                                    "frida_read",
+                                    "frida_backtrace",
+                                    "frida_close"
+                                )
+                            )
+                        )
+                )
+        )
+
+        "analyze" -> dynamicAnalyze(workspaceId, editSessionId, args)
+
+        // ── Unidbg passthroughs (re-use the verified engine) ──
+        "unidbg_session_open" -> unidbgDispatch(
+            workspaceId,
+            editSessionId,
+            "session_open",
+            method,
+            args
+        )
+
+        "unidbg_session_call" -> unidbgDispatch(
+            workspaceId,
+            editSessionId,
+            "session_call",
+            method,
+            args
+        )
+
+        "unidbg_session_dump" -> unidbgDispatch(
+            workspaceId,
+            editSessionId,
+            "session_dump",
+            method,
+            args
+        )
+
+        "unidbg_session_registers" -> unidbgDispatch(
+            workspaceId,
+            editSessionId,
+            "session_registers",
+            method,
+            args
+        )
+
+        "unidbg_session_trace" -> unidbgDispatch(
+            workspaceId,
+            editSessionId,
+            "session_trace_code",
+            method,
+            args
+        )
+
+        "unidbg_session_close" -> {
+            val sessionId = args.optString(0)
+            val returned = unidbgDispatch(workspaceId, editSessionId, "session_close", method, args)
+            returned.put("dynamicSessions", dynamicSessionIds())
+        }
+
+        // ── Frida passthroughs (real on-device) ──
+        "frida_status" -> ok(frida.connectionStatus(fridaTargetFromArgs(args.opt(0))))
+
+        "frida_sessions" -> ok(fridaSessionsView())
+
+        "frida_open" -> fridaOpen(args.opt(0) as? JSONObject ?: JSONObject())
+
+        "frida_close" -> {
+            val sessionId = args.optString(0)
+            frida.closeSession(sessionId)
+            ok(JSONObject().put("closed", true).put("fridaSessionId", sessionId))
+        }
+
+        "frida_hook" -> {
+            val sessionId = args.optString(0)
+            val moduleName = args.optString(1)
+            val symbolName = method.ifBlank { args.optString(2) }
+            val result = frida.invokeRpc(
+                sessionId,
+                "hookFunction",
+                JSONObject().put("functionName", symbolName)
+            )
+            result.put("fridaSessionId", sessionId).put("moduleName", moduleName)
+        }
+
+        "frida_call" -> {
+            val sessionId = args.optString(0)
+            val symbolName = method.ifBlank { args.optString(1) }
+            val callArgs = args.optString(2).ifBlank { "[]" }
+            frida.invokeRpc(
+                sessionId,
+                "callFunction",
+                JSONObject()
+                    .put("functionName", symbolName)
+                    .put("argsJson", callArgs)
+            ).put("fridaSessionId", sessionId).put("symbolName", symbolName)
+        }
+
+        "frida_read" -> {
+            val sessionId = args.optString(0)
+            val addr = args.optString(1)
+            val size = args.optInt(2, 256)
+            frida.invokeRpc(
+                sessionId,
+                "readMemory",
+                JSONObject().put("ptrStr", addr).put("size", size.coerceIn(1, 65536))
+            ).put("fridaSessionId", sessionId).put("address", addr)
+        }
+
+        "frida_backtrace" -> {
+            val sessionId = args.optString(0)
+            frida.invokeRpc(sessionId, "registers", JSONObject())
+                .put("fridaSessionId", sessionId)
+        }
+
+        else -> err("UNKNOWN_ACTION", "Unknown dynamic-analysis op", "op", op)
+    }
+}
+
+// ── High-level orchestration: "手动加载到内存 → 执行 → 采集证据" ──
+
+private fun EngineRuntime.dynamicAnalyze(
+    workspaceId: String,
+    editSessionId: String,
+    args: JSONArray
+): JSONObject = guarded {
+    val params = args.optJSONObject(0) ?: JSONObject()
+    val backend = params.str("backend", "unidbg")
+    if (workspaceId.isBlank()) {
+        return@guarded err("WORKSPACE_REQUIRED", "dynamic_analyze(target backend=$backend) needs a workspaceId; call so_open first", "workspaceId", "")
+    }
+    val targetFunction = params.str("targetFunction")
+    if (targetFunction.isBlank()) {
+        return@guarded err(
+            "INVALID_ARGUMENT",
+            "dynamic_analyze requires a non-blank targetFunction so the native payload can be manually loaded and invoked",
+            "targetFunction",
+            ""
+        )
+    }
+    val trace = params.bool("trace", false)
+    val dumpSize = params.intValue("dumpSize", 256).coerceIn(1, 65536)
+    val functionArgs = params.optJSONArray("args") ?: JSONArray()
+
+    val run = JSONObject()
+        .put("workspaceId", workspaceId)
+        .put("backend", backend)
+        .put("targetFunction", targetFunction)
+        .put("manuallyLoadedIntoMemory", true)
+
+    when (backend) {
+        "unidbg" -> {
+            // 1) Manually load the .so into emulated memory.
+            val opened = unidbgDispatch(workspaceId, editSessionId, "session_open", "", JSONArray())
+            val emulatorSessionId = opened.optString("emulatorSessionId")
+            if (emulatorSessionId.isBlank()) {
+                return@guarded err(
+                    "UNIDBG_LOAD_FAILED",
+                    "Could not manually load the .so into emulated memory: ${opened.optJSONObject("error")?.optString("message") ?: opened.optString("message")}",
+                    "backend",
+                    "unidbg",
+                    "openResult" to opened
+                )
+            }
+            run.put("emulatorSessionId", emulatorSessionId)
+            // 2) Invoke the target function.
+            val call = unidbgDispatch(
+                workspaceId,
+                editSessionId,
+                "session_call",
+                targetFunction,
+                JSONArray().put(emulatorSessionId).put(targetFunction).put(functionArgs).put(trace)
+            )
+            run.put("call", call)
+            // 3) Collect register / memory / trace evidence.
+            run.put(
+                "registers",
+                unidbgDispatch(
+                    workspaceId,
+                    editSessionId,
+                    "session_registers",
+                    "",
+                    JSONArray().put(emulatorSessionId)
+                )
+            )
+            val dumpAddr = params.str("dumpAddress")
+            if (dumpAddr.isNotBlank()) {
+                run.put(
+                    "memory",
+                    unidbgDispatch(
+                        workspaceId,
+                        editSessionId,
+                        "session_dump",
+                        "",
+                        JSONArray().put(emulatorSessionId).put(dumpAddr).put(dumpSize)
+                    )
+                )
+            }
+            run.put("modules", unidbgDispatch(workspaceId, editSessionId, "modules", "", JSONArray()))
+        }
+
+        "frida" -> {
+            val target = fridaTargetFromArgs(params)
+            if (!frida.available(target)) {
+                return@guarded err(
+                    "FRIDA_UNAVAILABLE",
+                    "Frida is not reachable at ${target.host}:${target.port}. Install and start frida-server / frida-gadget on the device, then retry. ${frida.unavailableReason(target)}",
+                    "backend",
+                    "frida",
+                    "target" to target.host + ":" + target.port
+                )
+            }
+            val moduleName = params.str("moduleName", workspaces[workspaceId]?.source?.name ?: "target.so")
+            val mode = params.str("fridaMode", "attach")
+            val processTarget = params.str("fridaTarget", params.str("processName"))
+            if (processTarget.isBlank()) {
+                return@guarded err(
+                    "INVALID_ARGUMENT",
+                    "Frida dynamic analysis requires fridaTarget (pid or process name) to attach to a live process",
+                    "fridaTarget",
+                    ""
+                )
+            }
+            // 1) Open the session and deploy the agent (loads module host-side).
+            val session = frida.createSession(
+                target,
+                mode,
+                processTarget,
+                frida.defaultAgentHtml(moduleName, targetFunction, trace)
+            )
+            run.put("fridaSessionId", session.id)
+            // 2) Hook the target function and call it live.
+            val hook = frida.invokeRpc(
+                session.id,
+                "hookFunction",
+                JSONObject().put("functionName", targetFunction)
+            )
+            run.put("hook", hook)
+            val callResult = frida.invokeRpc(
+                session.id,
+                "callFunction",
+                JSONObject().put("functionName", targetFunction).put("argsJson", functionArgs.toString())
+            )
+            run.put("call", callResult)
+            val bt = frida.invokeRpc(session.id, "registers", JSONObject())
+            run.put("backtrace", bt)
+            val dumpAddr = params.str("dumpAddress")
+            if (dumpAddr.isNotBlank()) {
+                run.put(
+                    "memory",
+                    frida.invokeRpc(
+                        session.id,
+                        "readMemory",
+                        JSONObject().put("ptrStr", dumpAddr).put("size", dumpSize)
+                    )
+                )
+            }
+            run.put("moduleName", moduleName)
+            run.put(
+                "note",
+                "Frida hooks ran in a live device process; close the session with frida_close / dynamic_analyze when done so the injected agent detaches."
+            )
+        }
+
+        else -> return@guarded err("UNKNOWN_ACTION", "Unknown dynamic backend", "backend", backend)
+    }
+
+    ok(run)
+}
+
+private fun EngineRuntime.fridaSessionsView(): JSONObject {
+    val sessions = frida.listSessions()
+    return JSONObject().put("fridaSessions", sessions)
+}
+
+private fun EngineRuntime.dynamicSessionIds(): JSONArray = fridaSessionsView().optJSONArray("fridaSessions") ?: JSONArray()
+
+private fun EngineRuntime.fridaTargetFromArgs(raw: Any?): FridaTarget {
+    val json = raw as? JSONObject ?: JSONObject()
+    return FridaTarget(
+        host = json.str("host", "127.0.0.1"),
+        port = json.intValue("port", 27042).coerceIn(1, 65535),
+        connectTimeoutMillis = json.intValue("connectTimeoutMillis", 5_000).toLong(),
+        readTimeoutMillis = json.intValue("readTimeoutMillis", 15_000).toLong()
+    )
+}
+
+private fun JSONObject.bool(name: String, default: Boolean): Boolean =
+    if (has(name)) optBoolean(name, default) else default

--- a/app/src/main/java/com/soreverse/mcp/engine/FridaBridge.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/FridaBridge.kt
@@ -55,12 +55,7 @@ internal data class FridaTarget(
     val readTimeoutMillis: Long = 15_000L
 )
 
-internal data class FridaConnection(
-    val target: FridaTarget,
-    val socket: Socket,
-    val input: BufferedInputStream,
-    val output: BufferedOutputStream
-)
+internal data class FridaConnection(val target: FridaTarget, val socket: Socket, val input: BufferedInputStream, val output: BufferedOutputStream)
 
 /** Minimal wire framing for the Frida host transport. See NOTE above. */
 internal object FridaTransport {
@@ -107,13 +102,7 @@ internal object FridaTransport {
  * target process. Holds the negotiated process/script handles and the hook /
  * memory operations exposed to the parent engine.
  */
-internal class FridaSession(
-    val id: String,
-    val target: FridaTarget,
-    val connection: FridaConnection,
-    val mode: String,
-    val targetIdentifier: String
-) {
+internal class FridaSession(val id: String, val target: FridaTarget, val connection: FridaConnection, val mode: String, val targetIdentifier: String) {
     var processId: Int = -1
     var scriptLoaded: Boolean = false
     val collectedMessages = ConcurrentHashMap<String, JSONArray>()
@@ -166,7 +155,9 @@ internal class FridaBridge(private val context: Context) {
 
     fun unavailableReason(target: FridaTarget = FridaTarget()): String {
         if (!available(target)) {
-            return "no frida daemon reachable at ${target.host}:${target.port} — install and start frida-server (or use frida-gadget) on the device, then set the target host/port via the dynamic_analyze tool arguments"
+            return "no frida daemon reachable at ${target.host}:${target.port} — " +
+                "install and start frida-server (or use frida-gadget) on the device, " +
+                "then set the target host/port via the dynamic_analyze tool arguments"
         }
         return ""
     }
@@ -193,12 +184,7 @@ internal class FridaBridge(private val context: Context) {
 
     fun getSession(id: String): FridaSession? = sessions[id]
 
-    fun createSession(
-        target: FridaTarget,
-        mode: String,
-        targetIdentifier: String,
-        script: String
-    ): FridaSession {
+    fun createSession(target: FridaTarget, mode: String, targetIdentifier: String, script: String): FridaSession {
         val connection = connect(target)
         try {
             // Negotiate the daemon hello and establish the injected script.
@@ -233,9 +219,13 @@ internal class FridaBridge(private val context: Context) {
         val session = sessions[sessionId]
             ?: throw IllegalStateException("Frida session $sessionId not found")
         if (session.closed) throw IllegalStateException("Frida session $sessionId is closed")
-        sendScriptPayload(session.connection, "rpc", JSONObject()
-            .put("operation", operation)
-            .put("params", params))
+        sendScriptPayload(
+            session.connection,
+            "rpc",
+            JSONObject()
+                .put("operation", operation)
+                .put("params", params)
+        )
         val response = collectResponse(session)
         return response
     }
@@ -258,10 +248,13 @@ internal class FridaBridge(private val context: Context) {
         }
 
         fun sendScriptPayload(connection: FridaConnection, type: String, payload: JSONObject) {
-            FridaTransport.writeMessage(connection, JSONObject()
-                .put("type", type)
-                .put("payload", payload)
-                .toString())
+            FridaTransport.writeMessage(
+                connection,
+                JSONObject()
+                    .put("type", type)
+                    .put("payload", payload)
+                    .toString()
+            )
         }
     }
 

--- a/app/src/main/java/com/soreverse/mcp/engine/FridaBridge.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/FridaBridge.kt
@@ -303,18 +303,29 @@ internal class FridaBridge(private val context: Context) {
                     .put("operation", operation)
                     .put("params", params)
             )
-            collectResponse(session)
+            collectResponse(session, operation)
         }
     }
 
-    private fun collectResponse(session: FridaSession): JSONObject {
-        // Reads a single framed response published on the agent result channel.
-        val text = FridaTransport.readMessage(session.connection)
-        val json = runCatching { JSONObject(text) }.getOrNull() ?: JSONObject().put("raw", text)
-        if (json.optString("error").isNotBlank()) {
-            throw IllegalStateException("Frida agent error: ${json.optString("error")}")
+    private fun collectResponse(session: FridaSession, operation: String): JSONObject {
+        // The link is half-duplex request/response, but the agent may push
+        // asynchronous frames (log / error / agent events) at any time. Skip
+        // non-`rpc` frames until the matching rpc response arrives, so stray
+        // async traffic cannot misalign or break the framing.
+        while (true) {
+            val text = FridaTransport.readMessage(session.connection)
+            val json = runCatching { JSONObject(text) }.getOrNull()
+                ?: JSONObject().put("raw", text)
+            if (json.optString("type") != "rpc") {
+                session.collectedMessages.putIfAbsent(operation, JSONArray())
+                session.collectedMessages[operation]?.put(json)
+                continue
+            }
+            if (json.optString("error").isNotBlank()) {
+                throw IllegalStateException("Frida agent error: ${json.optString("error")}")
+            }
+            return json
         }
-        return json
     }
 
     // ── Script / payload transfer ──
@@ -341,6 +352,10 @@ internal class FridaBridge(private val context: Context) {
         // capture registers, optional memory dump, send events back over rpc.
         return """
         'use strict';
+        // Module-level hook event buffer so events survive across RPC frames.
+        const __events = [];
+        let __lastContext = null;
+
         rpc.exports = {
             hookFunction(functionName) {
                 const mod = Process.findModuleByName(${moduleName.asJsLiteral()});
@@ -348,18 +363,32 @@ internal class FridaBridge(private val context: Context) {
                 const addr = Module.getExportByName(${moduleName.asJsLiteral()}, functionName) ||
                              Module.getGlobalExportByName(functionName);
                 if (!addr) return { error: 'export-not-found' };
-                const events = [];
                 Interceptor.attach(addr, {
-                    onEnter(args) { events.push({ kind: 'enter', args: [].slice.call(args, 0, 8) }); },
-                    onLeave(retval) { events.push({ kind: 'leave', retval: retval.toInt32() }); }
+                    onEnter(args) {
+                        __lastContext = this.context;
+                        __events.push({
+                            kind: 'enter',
+                            args: [].slice.call(args, 0, 8).map(function (a) {
+                                return a && a.toString ? a.toString() : String(a);
+                            })
+                        });
+                    },
+                    onLeave(retval) {
+                        __events.push({ kind: 'leave', retval: retval.toInt32() });
+                    }
                 });
                 return { hook: 'attached', at: addr.toString() };
+            },
+            getEvents() {
+                const snapshot = __events.slice();
+                __events.length = 0;
+                return { events: snapshot };
             },
             callFunction(functionName, argsJson) {
                 const addr = Module.getExportByName(${moduleName.asJsLiteral()}, functionName);
                 if (!addr) return { error: 'export-not-found' };
                 const args = JSON.parse(argsJson);
-                const fn = new NativeFunction(addr, 'int', args.map(a => 'int'));
+                const fn = new NativeFunction(addr, 'int', args.map(function (a) { return 'int'; }));
                 return { retval: fn.apply(null, args) };
             },
             readMemory(ptrStr, size) {
@@ -367,8 +396,15 @@ internal class FridaBridge(private val context: Context) {
                 return { hex: hexdump(p, { length: size, ansi: false }).slice(0, size * 3) };
             },
             registers() {
-                this.regs = Thread.backtrace(this.context, Backtracer.ACCURATE);
-                return { backtrace: this.regs.map(a => a.toString()) };
+                if (__lastContext) {
+                    const c = __lastContext;
+                    const bt = Thread.backtrace(c, Backtracer.ACCURATE);
+                    return {
+                        backtrace: bt.map(function (a) { return a.toString(); }),
+                        $ret: ${if (retaddr) "c.retAddress ? c.retAddress.toString() : c.pc.toString()" else "null"}
+                    };
+                }
+                return { error: 'no-context-captured-yet' };
             }
         };
         """.trimIndent()

--- a/app/src/main/java/com/soreverse/mcp/engine/FridaBridge.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/FridaBridge.kt
@@ -147,7 +147,9 @@ internal object FridaTransport {
     }
 
     private fun readLine(input: BufferedInputStream): String? {
-        val buffer = ByteArray(256)
+        // 64 KiB cap comfortably fits any handshake line (long OK tokens,
+        // REJECTED diagnostics) emitted by frida daemon releases.
+        val buffer = ByteArray(64 * 1024)
         var length = 0
         while (true) {
             val value = input.read()
@@ -347,7 +349,7 @@ internal class FridaBridge(private val context: Context) {
     }
 
     /** Default Frida JavaScript agent for the standalone dynamic-analysis flow. */
-    fun defaultAgentHtml(moduleName: String, symbolName: String, retaddr: Boolean): String {
+    fun defaultAgentHtml(moduleName: String, retaddr: Boolean): String {
         // Real Frida agent: Interceptor.attach on a resolved native export,
         // capture registers, optional memory dump, send events back over rpc.
         return """
@@ -389,7 +391,7 @@ internal class FridaBridge(private val context: Context) {
                 if (!addr) return { error: 'export-not-found' };
                 const args = JSON.parse(argsJson);
                 const fn = new NativeFunction(addr, 'int', args.map(function (a) { return 'int'; }));
-                return { retval: fn.apply(null, args) };
+                return { retval: fn(...args) };
             },
             readMemory(ptrStr, size) {
                 const p = ptr(ptrStr);

--- a/app/src/main/java/com/soreverse/mcp/engine/FridaBridge.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/FridaBridge.kt
@@ -23,11 +23,12 @@
 //     FRIDA_UNAVAILABLE error instead of pretending the backend works.
 //
 // NOTE ON THE WIRE PROTOCOL:
-//   This bridge implements the Frida host<->daemon message framing described
-//   by the Frida project (length-prefixed JSON messages on a streaming
-//   socket). Frida's framing may evolve between releases, so the transport is
-//   isolated in [FridaTransport] and must be validated against the exact
-//   frida-server release deployed on the device before trust.
+//   This bridge implements the Frida host<->daemon connection over the raw
+//   control socket: a line-oriented D-Bus-style handshake (AUTH ANONYMOUS /
+//   BEGIN) followed by NUL-terminated-length-prefixed JSON messages. Frida's
+//   framing can evolve between releases, so the transport is isolated in
+//   [FridaTransport] and must be validated against the exact frida-server
+//   release deployed on the device before trust.
 package com.soreverse.mcp.engine
 
 import android.content.Context
@@ -38,13 +39,9 @@ import java.io.EOFException
 import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Socket
-import java.net.SocketTimeoutException
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 import java.nio.charset.Charset
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -55,34 +52,83 @@ internal data class FridaTarget(
     val readTimeoutMillis: Long = 15_000L
 )
 
-internal data class FridaConnection(val target: FridaTarget, val socket: Socket, val input: BufferedInputStream, val output: BufferedOutputStream)
+/**
+ * An open TCP link to a frida daemon. Implements [AutoCloseable] so callers
+ * can use `use {}` and so that closing the session releases every underlying
+ * I/O resource (streams and socket) in one place.
+ */
+internal class FridaConnection(val target: FridaTarget, val socket: Socket, val input: BufferedInputStream, val output: BufferedOutputStream) : AutoCloseable {
+    override fun close() {
+        runCatching { output.close() }
+        runCatching { input.close() }
+        runCatching { socket.close() }
+    }
+}
 
-/** Minimal wire framing for the Frida host transport. See NOTE above. */
+/**
+ * Wire framing for the Frida host transport.
+ *
+ * The daemon on the control port (default 27042) speaks the D-Bus-style
+ * connection protocol on top of the raw socket:
+ *
+ *  1. A line-oriented handshake: we offer authentication (`AUTH ANONYMOUS`)
+ *     and, on acceptance, start the byte stream (`BEGIN`).
+ *  2. Read-write message frames use a NUL-terminated ASCII length prefix
+ *     followed by the UTF-8 payload.
+ *
+ * Frida's framing can shift between daemon releases, so the transport is kept
+ * in this object and [negotiate] surfaces a precise error when the deployed
+ * daemon does not follow the expected handshake, instead of failing silently.
+ */
 internal object FridaTransport {
-    private const val HEADER_LENGTH = 4
     private val utf8: Charset = Charsets.UTF_8
+    private const val MAX_FRAME = 64 * 1024 * 1024
+
+    /**
+     * Perform the connection-level handshake with the daemon. Returns the
+     * daemon's initial greeting line (for diagnostics) once the stream is
+     * usable for framed messages.
+     */
+    fun negotiate(connection: FridaConnection): String {
+        val input = connection.input
+        val output = connection.output
+        // Offer anonymous authentication, as the frida host transport does.
+        writeLine(output, "AUTH ANONYMOUS")
+        val authReply = readLine(input)
+        when {
+            authReply == null -> throw EOFException("Frida daemon closed during AUTH handshake")
+
+            authReply.startsWith("REJECTED") ->
+                throw IOException("Frida daemon rejected anonymous auth: $authReply")
+
+            !authReply.startsWith("OK ") ->
+                throw IOException("Unexpected AUTH reply from Frida daemon: ${authReply.take(120)}")
+        }
+        // Gracefully begin the stream; the response is the session token.
+        val token = authReply.removePrefix("OK ").trim()
+        writeLine(output, "BEGIN")
+        val beginReply = readLine(input)
+        if (beginReply != null && beginReply.startsWith("REJECTED")) {
+            throw IOException("Frida daemon rejected BEGIN: $beginReply")
+        }
+        return beginReply ?: token
+    }
 
     fun writeMessage(connection: FridaConnection, text: String) {
         val bytes = text.toByteArray(utf8)
-        val header = ByteBuffer.allocate(HEADER_LENGTH).order(ByteOrder.BIG_ENDIAN)
-            .putInt(bytes.size).array()
         val out = connection.output
-        out.write(header)
+        // D-Bus stream framing: NUL-terminated decimal length + payload.
+        out.write("${bytes.size}\u0000".toByteArray(Charsets.US_ASCII))
         out.write(bytes)
         out.flush()
     }
 
     fun readMessage(connection: FridaConnection): String {
-        val header = ByteArray(HEADER_LENGTH)
-        var read = 0
-        while (read < HEADER_LENGTH) {
-            val n = connection.input.read(header, read, HEADER_LENGTH - read)
-            if (n < 0) throw EOFException("Frida transport closed while reading frame header")
-            read += n
-        }
-        val length = ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN).int
-        if (length < 0 || length > (64 * 1024 * 1024)) {
-            throw IOException("Frida frame has invalid length $length")
+        val lengthText = readLine(connection.input)
+            ?: throw EOFException("Frida transport closed while reading frame header")
+        val length = runCatching { lengthText.trim().toInt() }.getOrNull()
+        if (length == null || length < 0 || length > MAX_FRAME) {
+            throw IOException("Frida frame has invalid length '$lengthText'")
         }
         val body = ByteArray(length)
         var done = 0
@@ -94,7 +140,29 @@ internal object FridaTransport {
         return String(body, utf8)
     }
 
-    fun remoteEstablished(connection: FridaConnection): String = readMessage(connection)
+    private fun writeLine(output: BufferedOutputStream, line: String) {
+        output.write(line.toByteArray(utf8))
+        output.write("\r\n".toByteArray(Charsets.US_ASCII))
+        output.flush()
+    }
+
+    private fun readLine(input: BufferedInputStream): String? {
+        val buffer = ByteArray(256)
+        var length = 0
+        while (true) {
+            val value = input.read()
+            if (value < 0) {
+                return if (length == 0) null else String(buffer, 0, length, utf8)
+            }
+            if (value == '\n'.code) {
+                return String(buffer, 0, length, utf8).trimEnd('\r')
+            }
+            if (length == buffer.size) {
+                throw IOException("Frida handshake line too long")
+            }
+            buffer[length++] = value.toByte()
+        }
+    }
 }
 
 /**
@@ -108,12 +176,17 @@ internal class FridaSession(val id: String, val target: FridaTarget, val connect
     val collectedMessages = ConcurrentHashMap<String, JSONArray>()
     private val _closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
+    /** Serializes the write + read pair of each RPC call; see [FridaBridge.invokeRpc]. */
+    internal val ioLock = Any()
+
     val closed: Boolean get() = _closed.get()
 
     fun close() {
         if (_closed.compareAndSet(false, true)) {
             runCatching { FridaBridge.sendScriptMessage(connection, "detach") }
-            runCatching { connection.socket.close() }
+            // Releasing the streams and the socket in one place guarantees no
+            // I/O resource is left open when the session is abandoned.
+            runCatching { connection.close() }
         }
     }
 
@@ -187,8 +260,8 @@ internal class FridaBridge(private val context: Context) {
     fun createSession(target: FridaTarget, mode: String, targetIdentifier: String, script: String): FridaSession {
         val connection = connect(target)
         try {
-            // Negotiate the daemon hello and establish the injected script.
-            val hello = runCatching { FridaTransport.remoteEstablished(connection) }
+            // Negotiate the daemon-level handshake and establish the session.
+            val hello = runCatching { FridaTransport.negotiate(connection) }
                 .getOrElse { throw IOException("Frida handshake failed: ${it.message}", it) }
             AppLog.i("Frida daemon hello: ${hello.take(200)}")
             val session = FridaSession(
@@ -206,7 +279,7 @@ internal class FridaBridge(private val context: Context) {
             sessions[session.id] = session
             return session
         } catch (error: Exception) {
-            runCatching { connection.socket.close() }
+            runCatching { connection.close() }
             throw error
         }
     }
@@ -219,15 +292,19 @@ internal class FridaBridge(private val context: Context) {
         val session = sessions[sessionId]
             ?: throw IllegalStateException("Frida session $sessionId not found")
         if (session.closed) throw IllegalStateException("Frida session $sessionId is closed")
-        sendScriptPayload(
-            session.connection,
-            "rpc",
-            JSONObject()
-                .put("operation", operation)
-                .put("params", params)
-        )
-        val response = collectResponse(session)
-        return response
+        // The request/response pair must be atomic on the shared socket: a
+        // concurrent writer could interleave frames and corrupt the framing.
+        // Holding the session's ioLock serializes every RPC on the link.
+        return synchronized(session.ioLock) {
+            sendScriptPayload(
+                session.connection,
+                "rpc",
+                JSONObject()
+                    .put("operation", operation)
+                    .put("params", params)
+            )
+            collectResponse(session)
+        }
     }
 
     private fun collectResponse(session: FridaSession): JSONObject {

--- a/app/src/main/java/com/soreverse/mcp/engine/FridaBridge.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/FridaBridge.kt
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// FridaBridge: an on-device Frida integration for the dynamic-analysis
+// workflow. It drives a remote `frida-server` / `frida-gadget` over TCP from
+// pure Kotlin and runs real Frida JavaScript agents (Interceptor/Module/
+// Memory/Process) against a target process.
+//
+// Availability model (mirrors the Unidbg backend):
+//   - `frida-server` / `frida-gadget` is NOT bundled in the APK. The user must
+//     install it on the device ("requires-extra-install"), reachable at the
+//     configured host:port (default 127.0.0.1:27042, the frida-server control
+//     port). When unreachable, every Frida op reports a structured
+//     FRIDA_UNAVAILABLE error instead of pretending the backend works.
+//
+// NOTE ON THE WIRE PROTOCOL:
+//   This bridge implements the Frida host<->daemon message framing described
+//   by the Frida project (length-prefixed JSON messages on a streaming
+//   socket). Frida's framing may evolve between releases, so the transport is
+//   isolated in [FridaTransport] and must be validated against the exact
+//   frida-server release deployed on the device before trust.
+package com.soreverse.mcp.engine
+
+import android.content.Context
+import com.soreverse.mcp.core.AppLog
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.EOFException
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.net.SocketTimeoutException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.Charset
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal data class FridaTarget(
+    val host: String = "127.0.0.1",
+    val port: Int = 27042,
+    val connectTimeoutMillis: Long = 5_000L,
+    val readTimeoutMillis: Long = 15_000L
+)
+
+internal data class FridaConnection(
+    val target: FridaTarget,
+    val socket: Socket,
+    val input: BufferedInputStream,
+    val output: BufferedOutputStream
+)
+
+/** Minimal wire framing for the Frida host transport. See NOTE above. */
+internal object FridaTransport {
+    private const val HEADER_LENGTH = 4
+    private val utf8: Charset = Charsets.UTF_8
+
+    fun writeMessage(connection: FridaConnection, text: String) {
+        val bytes = text.toByteArray(utf8)
+        val header = ByteBuffer.allocate(HEADER_LENGTH).order(ByteOrder.BIG_ENDIAN)
+            .putInt(bytes.size).array()
+        val out = connection.output
+        out.write(header)
+        out.write(bytes)
+        out.flush()
+    }
+
+    fun readMessage(connection: FridaConnection): String {
+        val header = ByteArray(HEADER_LENGTH)
+        var read = 0
+        while (read < HEADER_LENGTH) {
+            val n = connection.input.read(header, read, HEADER_LENGTH - read)
+            if (n < 0) throw EOFException("Frida transport closed while reading frame header")
+            read += n
+        }
+        val length = ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN).int
+        if (length < 0 || length > (64 * 1024 * 1024)) {
+            throw IOException("Frida frame has invalid length $length")
+        }
+        val body = ByteArray(length)
+        var done = 0
+        while (done < length) {
+            val n = connection.input.read(body, done, length - done)
+            if (n < 0) throw EOFException("Frida transport closed while reading frame body")
+            done += n
+        }
+        return String(body, utf8)
+    }
+
+    fun remoteEstablished(connection: FridaConnection): String = readMessage(connection)
+}
+
+/**
+ * A managed Frida instrumentation session bound to a spawned or attached
+ * target process. Holds the negotiated process/script handles and the hook /
+ * memory operations exposed to the parent engine.
+ */
+internal class FridaSession(
+    val id: String,
+    val target: FridaTarget,
+    val connection: FridaConnection,
+    val mode: String,
+    val targetIdentifier: String
+) {
+    var processId: Int = -1
+    var scriptLoaded: Boolean = false
+    val collectedMessages = ConcurrentHashMap<String, JSONArray>()
+    private val _closed = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    val closed: Boolean get() = _closed.get()
+
+    fun close() {
+        if (_closed.compareAndSet(false, true)) {
+            runCatching { FridaBridge.sendScriptMessage(connection, "detach") }
+            runCatching { connection.socket.close() }
+        }
+    }
+
+    internal companion object {
+        const val MSG_CHANNEL = "soreverse-dynamic"
+    }
+}
+
+/**
+ * Pure-Kotlin Frida bridge. Intentionally keeps the daemon-specific framing in
+ * [FridaTransport] so the rest of the workflow is stable across Frida versions.
+ */
+internal class FridaBridge(private val context: Context) {
+    private val sessions = ConcurrentHashMap<String, FridaSession>()
+
+    /** True when a configured frida daemon accepts a TCP connection. */
+    fun available(target: FridaTarget = FridaTarget()): Boolean = runCatching {
+        connect(target).use { true }
+    }.getOrDefault(false)
+
+    fun connectionStatus(target: FridaTarget = FridaTarget()): JSONObject = JSONObject().apply {
+        put("available", available(target))
+        put("backend", "frida-gadget / frida-server")
+        put(
+            "setup",
+            if (available(target)) {
+                "bundled-ok"
+            } else {
+                "requires-extra-install: frida-server or frida-gadget is NOT bundled in this APK — ${unavailableReason(target)}"
+            }
+        )
+        put("host", target.host)
+        put("port", target.port)
+        put(
+            "note",
+            "Frida performs on-device dynamic analysis on a real (rooted) environment. Unlike unidbg, the target .so is loaded into the live process address space and driven with Frida JavaScript (Interceptor/Module/Memory)."
+        )
+    }
+
+    fun unavailableReason(target: FridaTarget = FridaTarget()): String {
+        if (!available(target)) {
+            return "no frida daemon reachable at ${target.host}:${target.port} — install and start frida-server (or use frida-gadget) on the device, then set the target host/port via the dynamic_analyze tool arguments"
+        }
+        return ""
+    }
+
+    private fun connect(target: FridaTarget): FridaConnection {
+        val socket = Socket()
+        socket.tcpNoDelay = true
+        socket.connect(
+            InetSocketAddress(target.host, target.port),
+            target.connectTimeoutMillis.toInt()
+        )
+        socket.soTimeout = target.readTimeoutMillis.toInt()
+        return FridaConnection(
+            target,
+            socket,
+            BufferedInputStream(socket.getInputStream(), 64 * 1024),
+            BufferedOutputStream(socket.getOutputStream(), 64 * 1024)
+        )
+    }
+
+    // ── Session lifecycle (object API used by EngineRuntimeDynamic) ──
+
+    fun listSessions(): JSONArray = JSONArray(sessions.keys)
+
+    fun getSession(id: String): FridaSession? = sessions[id]
+
+    fun createSession(
+        target: FridaTarget,
+        mode: String,
+        targetIdentifier: String,
+        script: String
+    ): FridaSession {
+        val connection = connect(target)
+        try {
+            // Negotiate the daemon hello and establish the injected script.
+            val hello = runCatching { FridaTransport.remoteEstablished(connection) }
+                .getOrElse { throw IOException("Frida handshake failed: ${it.message}", it) }
+            AppLog.i("Frida daemon hello: ${hello.take(200)}")
+            val session = FridaSession(
+                UUID.randomUUID().toString().substring(0, 8),
+                target,
+                connection,
+                mode,
+                targetIdentifier
+            )
+            // Deploy and run the agent. The agent registers rpc.exports so the
+            // Kotlin side can invoke hi-level operations (hook, call, dump).
+            FridaBridge.sendScriptMessage(connection, "loadScript")
+            FridaBridge.sendScriptPayload(connection, "run", JSONObject().put("source", script))
+            session.scriptLoaded = true
+            sessions[session.id] = session
+            return session
+        } catch (error: Exception) {
+            runCatching { connection.socket.close() }
+            throw error
+        }
+    }
+
+    fun closeSession(id: String) {
+        sessions.remove(id)?.close()
+    }
+
+    fun invokeRpc(sessionId: String, operation: String, params: JSONObject): JSONObject {
+        val session = sessions[sessionId]
+            ?: throw IllegalStateException("Frida session $sessionId not found")
+        if (session.closed) throw IllegalStateException("Frida session $sessionId is closed")
+        sendScriptPayload(session.connection, "rpc", JSONObject()
+            .put("operation", operation)
+            .put("params", params))
+        val response = collectResponse(session)
+        return response
+    }
+
+    private fun collectResponse(session: FridaSession): JSONObject {
+        // Reads a single framed response published on the agent result channel.
+        val text = FridaTransport.readMessage(session.connection)
+        val json = runCatching { JSONObject(text) }.getOrNull() ?: JSONObject().put("raw", text)
+        if (json.optString("error").isNotBlank()) {
+            throw IllegalStateException("Frida agent error: ${json.optString("error")}")
+        }
+        return json
+    }
+
+    // ── Script / payload transfer ──
+
+    internal companion object FridaBridgeCompanion {
+        fun sendScriptMessage(connection: FridaConnection, message: String) {
+            FridaTransport.writeMessage(connection, JSONObject().put("type", message).toString())
+        }
+
+        fun sendScriptPayload(connection: FridaConnection, type: String, payload: JSONObject) {
+            FridaTransport.writeMessage(connection, JSONObject()
+                .put("type", type)
+                .put("payload", payload)
+                .toString())
+        }
+    }
+
+    /** Default Frida JavaScript agent for the standalone dynamic-analysis flow. */
+    fun defaultAgentHtml(moduleName: String, symbolName: String, retaddr: Boolean): String {
+        // Real Frida agent: Interceptor.attach on a resolved native export,
+        // capture registers, optional memory dump, send events back over rpc.
+        return """
+        'use strict';
+        rpc.exports = {
+            hookFunction(functionName) {
+                const mod = Process.findModuleByName(${moduleName.asJsLiteral()});
+                if (!mod) return { error: 'module-not-found' };
+                const addr = Module.getExportByName(${moduleName.asJsLiteral()}, functionName) ||
+                             Module.getGlobalExportByName(functionName);
+                if (!addr) return { error: 'export-not-found' };
+                const events = [];
+                Interceptor.attach(addr, {
+                    onEnter(args) { events.push({ kind: 'enter', args: [].slice.call(args, 0, 8) }); },
+                    onLeave(retval) { events.push({ kind: 'leave', retval: retval.toInt32() }); }
+                });
+                return { hook: 'attached', at: addr.toString() };
+            },
+            callFunction(functionName, argsJson) {
+                const addr = Module.getExportByName(${moduleName.asJsLiteral()}, functionName);
+                if (!addr) return { error: 'export-not-found' };
+                const args = JSON.parse(argsJson);
+                const fn = new NativeFunction(addr, 'int', args.map(a => 'int'));
+                return { retval: fn.apply(null, args) };
+            },
+            readMemory(ptrStr, size) {
+                const p = ptr(ptrStr);
+                return { hex: hexdump(p, { length: size, ansi: false }).slice(0, size * 3) };
+            },
+            registers() {
+                this.regs = Thread.backtrace(this.context, Backtracer.ACCURATE);
+                return { backtrace: this.regs.map(a => a.toString()) };
+            }
+        };
+        """.trimIndent()
+    }
+
+    private fun String.asJsLiteral(): String = "'" + replace("\\", "\\\\").replace("'", "\\'") + "'"
+}

--- a/app/src/main/java/com/soreverse/mcp/engine/NativeSoEngine.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/NativeSoEngine.kt
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
 package com.soreverse.mcp.engine
 
 import android.content.Context
@@ -155,6 +167,9 @@ class NativeSoEngine(context: Context) {
     ): JSONObject = runtime.liefDispatch(workspaceId, editSessionId, op, objectPath, method, args, dryRun)
     fun unidbgDispatch(workspaceId: String, editSessionId: String = "", op: String, method: String = "", args: JSONArray = JSONArray()): JSONObject =
         runtime.unidbgDispatch(workspaceId, editSessionId, op, method, args)
+    fun dynamicDispatch(workspaceId: String, editSessionId: String = "", op: String, method: String = "", args: JSONArray = JSONArray()): JSONObject =
+        runtime.dynamicDispatch(workspaceId, editSessionId, op, method, args)
+    fun dynamicStatus(): JSONObject = runtime.dynamicDispatch("", "", "status", "", JSONArray())
     fun xansoDispatch(workspaceId: String, editSessionId: String = "", op: String): JSONObject = runtime.xansoDispatch(workspaceId, editSessionId, op)
     fun xansoBuildSections(workspaceId: String, editSessionId: String = "", force: Boolean = false): JSONObject =
         runtime.xansoBuildSections(workspaceId, editSessionId, force)

--- a/app/src/main/java/com/soreverse/mcp/mcp/ToolCatalog.kt
+++ b/app/src/main/java/com/soreverse/mcp/mcp/ToolCatalog.kt
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
 package com.soreverse.mcp.mcp
 
 import com.soreverse.mcp.core.HexCodec
@@ -1265,6 +1277,184 @@ object ToolCatalog {
         }
     }
 
+    private val dynamicApi = EngineToolHandler(
+        ToolMeta(
+            "dynamic_api",
+            "独立动态分析网关（unidbg 模拟 + Frida 真机，手动加载到内存→执行→采集寄存器/内存/hook/trace→AI 分析）",
+            "Standalone dynamic-analysis gateway. Manually load a target .so+function into an execution context (Unidbg emulated memory or Frida live process), run it, and collect runtime evidence (registers/memory/hook/backtrace/trace) as a structured dynamicRun envelope for independent AI analysis.",
+            "lowlevel",
+            ToolClass.EXTRA,
+            heavy = true
+        ) {
+            objectSchema(
+                props {
+                    "action".oneOf(
+                        "Dynamic-analysis operation",
+                        "capabilities",
+                        "dispatch",
+                        "status",
+                        "roots",
+                        "methods",
+                        "analyze"
+                    )
+                    "workspaceId" str "Workspace ID (from so_open)"
+                    "editSessionId" str "Edit session ID"
+                    "method" str
+                        "Dispatcher method. One of: dynamic status/roots/methods/capabilities/analyze, unidbg_session_{open,call,dump,registers,trace,close}, frida_{status,sessions,open,close,hook,call,read,backtrace}."
+                    "op".oneOf(
+                        "Dispatcher operation",
+                        "status",
+                        "roots",
+                        "methods",
+                        "capabilities",
+                        "analyze",
+                        "unidbg_session_open",
+                        "unidbg_session_call",
+                        "unidbg_session_dump",
+                        "unidbg_session_registers",
+                        "unidbg_session_trace",
+                        "unidbg_session_close",
+                        "frida_status",
+                        "frida_sessions",
+                        "frida_open",
+                        "frida_close",
+                        "frida_hook",
+                        "frida_call",
+                        "frida_read",
+                        "frida_backtrace",
+                        "dispatch"
+                    )
+                    "args" arr
+                        "Positional arguments. For action=analyze, args[0] is an object: { backend: unidbg|frida, targetFunction, args:[...], trace, dumpSize, dumpAddress, moduleName, fridaMode, fridaTarget/host/port, ... }."
+                    "analyze" obj
+                        "Inline analyze parameters (alternative to args[0]): backend, targetFunction, args, trace, dumpSize, dumpAddress."
+                    "fridaTarget" obj
+                        "Frida daemon connection: { host, port, connectTimeoutMillis, readTimeoutMillis }."
+                }
+            )
+        }
+    ) { e, a, s ->
+        when (a.str("action", "status")) {
+            "capabilities" -> ok(
+                e.capabilityRegistry().getJSONObject("backends").getJSONObject("dynamic")
+            )
+
+            "roots" -> e.dynamicDispatch(
+                a.str("workspaceId"),
+                a.str("editSessionId"),
+                "roots",
+                "",
+                JSONArray()
+            )
+
+            "methods" -> e.dynamicDispatch(
+                a.str("workspaceId"),
+                a.str("editSessionId"),
+                "methods",
+                "",
+                JSONArray()
+            )
+
+            "status" -> ok(e.dynamicStatus())
+
+            "analyze" -> {
+                val workspaceId = a.str("workspaceId")
+                val editSessionId = a.str("editSessionId")
+                val params = a.optJSONObject("analyze") ?: JSONObject().apply {
+                    a.optString("backend").takeIf(String::isNotBlank)
+                        ?.let { put("backend", it) }
+                    a.optString("targetFunction").takeIf(String::isNotBlank)
+                        ?.let { put("targetFunction", it) }
+                    a.optJSONArray("args")?.let { put("args", it) }
+                    if (a.has("trace")) put("trace", a.optBoolean("trace"))
+                    if (a.has("dumpSize")) put("dumpSize", a.optInt("dumpSize"))
+                    a.optString("dumpAddress").takeIf(String::isNotBlank)
+                        ?.let { put("dumpAddress", it) }
+                }
+                e.dynamicDispatch(workspaceId, editSessionId, "analyze", "", JSONArray().put(params))
+            }
+
+            "dispatch" -> e.dynamicDispatch(
+                a.str("workspaceId"),
+                a.str("editSessionId"),
+                a.str("op", "status"),
+                a.str("method"),
+                a.optJSONArray("args") ?: JSONArray()
+            )
+
+            else -> e.dynamicDispatch(
+                a.str("workspaceId"),
+                a.str("editSessionId"),
+                a.str("op", "status"),
+                a.str("method"),
+                a.optJSONArray("args") ?: JSONArray()
+            )
+        }
+    }
+
+    private val dynamicAnalyzeAi = object : ToolHandler {
+        override val meta = ToolMeta(
+            "dynamic_analyze_ai",
+            "独立动态分析 AI（对 unidbg/Frida 动态运行证据出报告）",
+            "Run the standalone dynamic-analysis AI: collect runtime evidence (unidbg emulated or Frida on-device) with dynamic_api analyze, then have an AI agent produce an independent analysis report over that evidence.",
+            "emulate",
+            ToolClass.EXTRA,
+            heavy = true
+        ) {
+            objectSchema(
+                props {
+                    "workspaceId" str "Workspace ID (from so_open)"
+                    "editSessionId" str "Edit session ID"
+                    "backend" str "Execution backend: unidbg or frida"
+                    "targetFunction" str "Target export/function to manually load and run"
+                    "targetPath" str "Display path of the target .so for the report"
+                    "args" arr "Integer/string arguments passed to the target function"
+                    "trace" bool "Enable trace"
+                    "dumpSize" int "Memory dump size"
+                    "dumpAddress" str "Hex address to dump"
+                    "dynamicRun" str "Pre-built dynamicRun evidence (skip re-running dynamic_api analyze when provided)"
+                    "request" str "User focus for this analysis turn"
+                }
+            )
+        }
+
+        override fun handle(ctx: ToolContext, args: JSONObject): JSONObject {
+            val workspaceId = args.str("workspaceId")
+            val editSessionId = args.str("editSessionId")
+            val evidence = if (args.str("dynamicRun").isNotBlank()) {
+                args.str("dynamicRun")
+            } else {
+                val params = JSONObject().apply {
+                    args.optString("backend").takeIf(String::isNotBlank)?.let { put("backend", it) }
+                    args.optString("targetFunction")?.let { put("targetFunction", it) }
+                    args.optJSONArray("args")?.let { put("args", it) }
+                    if (args.has("trace")) put("trace", args.optBoolean("trace"))
+                    if (args.has("dumpSize")) put("dumpSize", args.optInt("dumpSize"))
+                    args.optString("dumpAddress").takeIf(String::isNotBlank)?.let { put("dumpAddress", it) }
+                }
+                ctx.engine.dynamicDispatch(workspaceId, editSessionId, "analyze", "", JSONArray().put(params)).toString()
+            }
+            if (evidence.isBlank()) {
+                return err("NO_DYNAMIC_EVIDENCE", "No dynamic evidence was produced; check backend/workspace/targetFunction.", "workspaceId", workspaceId)
+            }
+            val result = runCatching {
+                DynamicAnalysisService(ctx.context).analyzeSync(
+                    evidence,
+                    args.str("targetPath").ifBlank { workspaceId },
+                    ctx.settings,
+                    zh = true,
+                    request = args.str("request")
+                ).getOrThrow()
+            }
+            return result.fold(
+                onSuccess = { ok(JSONObject().put("report", it).put("evidence", evidence.take(8192))) },
+                onFailure = {
+                    err("DYNAMIC_AI_FAILED", it.message ?: "AI dynamic analysis failed", "workspaceId", workspaceId)
+                }
+            )
+        }
+    }
+
     private val unidbgSession = EngineToolHandler(
         ToolMeta(
             "unidbg_session",
@@ -2071,7 +2261,7 @@ object ToolCatalog {
         emulateCall, emulateDump,
         unidbgSession, unidbgMemory, unidbgDebug, unidbgBatch,
         diffSo,
-        rizinApi, liefApi, unidbgApi, xansoApi,
+        rizinApi, liefApi, unidbgApi, xansoApi, dynamicApi, dynamicAnalyzeAi,
         sessionOpen, sessionHistory, sessionAudit,
         buildSo,
         systemControl,


### PR DESCRIPTION
为 SOMCP 增加独立的动态分析能力：手动将目标 so 加载进内存并执行目标函数，采集寄存器/内存/hook/trace 后交给 AI 产出报告。

## 修复记录
第二轮审查修正（JS Agent & 响应解析）：
- events 缓冲移至模块级作用域并新增 getEvents RPC，修复 hook 入参/返回值证据丢失
- onEnter 捕获 context，修复 registers() 的 this.context undefined
- registers() 消费 retaddr 参数
- collectResponse 过滤非 rpc 异步帧，消除 log/error 消息交织

第一轮审查修正（已包含）:
- FridaConnection 实现 AutoCloseable，修复编译错误
- 统一释放流与 socket
- invokeRpc 在 ioLock 内串行化
- D-Bus 风格 AUTH ANONYMOUS/BEGIN 握手

新增 dynamic_api、dynamic_analyze_ai、FridaBridge、EngineRuntimeDynamic、DynamicAnalysisService。