### PR TITLE
fix(release): bundle Unidbg native libs into release APKs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,31 @@ jobs:
       - name: Build native backends (Rizin + LIEF)
         run: bash build-native-android.sh
 
+      - name: Build Unidbg native libs (capstone/keystone/unicorn)
+        run: |
+          set -euo pipefail
+          # Cross-compile the Android natives required by the Unidbg backend
+          # (libcapstone.so / libkeystone.so / libunicorn.so). unidbg 0.9.9
+          # Maven artifacts only ship linux_64/linux_aarch64 .so, so without
+          # this step the release APK would be published WITHOUT the libs and
+          # emulate_* would return EMULATOR_UNAVAILABLE (see issue #35).
+          # This step is fatal on failure so a release can never be built
+          # without the Unidbg natives again.
+          for abi in arm64-v8a armeabi-v7a x86 x86_64; do
+            bash build-unidbg-native.sh --abi "$abi"
+          done
+          # Sanity-check that every ABI now has all three natives in jniLibs
+          # before the APK is assembled; abort if any is missing.
+          for abi in arm64-v8a armeabi-v7a x86 x86_64; do
+            for lib in capstone keystone unicorn; do
+              test -f "app/src/main/jniLibs/$abi/lib$lib.so" || {
+                echo "::error::missing app/src/main/jniLibs/$abi/lib$lib.so after build-unidbg-native.sh"
+                exit 1
+              }
+            done
+          done
+          echo "Unidbg native libs present for all four ABIs."
+
       - name: Restore release signing keystore
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Release 输出体积随原生后端更新变化，以 GitHub Release 资产页�
 - 编辑会话：snapshot、rollback、undo、redo、check、audit、persist。
 - 构建导出：自动改名/覆盖、patch report、多输出变体、镜像到工作目录。
 - Cloudflare Tunnel：quick/named 隧道、keepalive、状态统计。
-- 可选 Unidbg：`emulate_call`、`emulate_dump`。**注意**：Unidbg 的 Android 原生库（`libcapstone.so` / `libkeystone.so` / `libunicorn.so` / `libjnidispatch.so`）不随 APK 内置，需自行交叉编译 unidbg 上游 native 并放入 `app/src/main/jniLibs/<abi>/` 后重新构建，或在设备上额外安装；未内置时 `system_control(action=status)` 的 `emulation.setup` 会明确标注 `requires-extra-install`，`emulate_*` 调用返回 `EMULATOR_UNAVAILABLE` 并说明缺失原因，不会伪装成可用。
+- 可选 Unidbg：`emulate_call`、`emulate_dump`。**注意**：Unidbg 的 Android 原生库（`libcapstone.so` / `libkeystone.so` / `libunicorn.so` / `libjnidispatch.so`）不随 Debug APK 内置，需自行交叉编译 unidbg 上游 native 并放入 `app/src/main/jniLibs/<abi>/` 后重新构建，或在设备上额外安装；**官方 Release APK（v1.0.18+）已内置 arm64-v8a / armeabi-v7a / x86 / x86_64 全部四个 ABI 的 Unidbg 原生库**，直接安装即可使用。库缺失时 `system_control(action=status)` 的 `emulation.setup` 会明确标注 `requires-extra-install`，`emulate_*` 调用返回 `EMULATOR_UNAVAILABLE` 并说明缺失原因，不会伪装成可用。
 - 完全离线 Flutter AOT 分析：内置 Flutter 3.44.2–3.44.7 / Dart 3.12.2 arm64 Blutter Runner；其他版本返回明确的不支持信息。
 - Cloudflare 永久隧道支持配置要展示的 HTTPS 公网地址；认证失败会停止重连并提示更新 token。
 - APK 内 SO 使用流式扫描与按需提取，分析页可一键释放工作区、索引缓存和已结束的 Blutter 数据。


### PR DESCRIPTION
Fixes https://github.com/bilieebiliee1-design/SOMCP/issues/35

## 问题
使用 Unidbg 模拟后端时提示缺少原生库，emulate_* 返回 EMULATOR_UNAVAILABLE。unidbg 0.9.9 Maven 产物仅含 linux 平台 .so，无 Android 预编译版，此前 Release 流程未编译/打包这些库。

## 改动
- release.yml：新增 Build Unidbg native libs 步骤，为四 ABI 交叉编译 capstone/keystone/unicorn 并校验产物存在，失败即发布失败。
- README.md：更新 Unidbg 说明，注明 Release APK (v1.0.18+) 已内置四 ABI 原生库。

## 验证
- YAML 语法校验通过；完整原生编译由 CI 验证。