### PR TITLE
chore(release): bump version to 1.0.19 (versionCode 20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SOMCP 是一个运行在 Android 手机上的本地 SO 逆向 MCP 服务器。它通过 Streamable HTTP 暴露 MCP 工具，让客户端可以在手机上完成 ELF 结构分析、Rizin 反汇编/分析、LIEF ELF 修复/重写、补丁会话、构建导出、Cloudflare Tunnel 暴露和可选 APK MCP 桥接。
 
-当前版本：`1.0.18`
+当前版本：`1.0.19`
 
 包名：`com.soreverse.mcp`
 
@@ -39,11 +39,11 @@ app/build/outputs/apk/release/app-universal-release.apk
 推荐 Release tag 使用 `v<versionName>`，并上传按 ABI 命名的 APK：
 
 ```text
-SOMCP-1.0.18-arm64-v8a.apk
-SOMCP-1.0.18-armeabi-v7a.apk
-SOMCP-1.0.18-x86.apk
-SOMCP-1.0.18-x86_64.apk
-SOMCP-1.0.18-universal.apk
+SOMCP-1.0.19-arm64-v8a.apk
+SOMCP-1.0.19-armeabi-v7a.apk
+SOMCP-1.0.19-x86.apk
+SOMCP-1.0.19-x86_64.apk
+SOMCP-1.0.19-universal.apk
 ```
 
 可同时上传同名 `<apk>.sha256` 或统一的 `SHA256SUMS`。检测器会优先选择当前设备 ABI，存在校验资产时会在安装前强制验证 SHA-256。

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,17 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
 import java.util.Properties
 
 plugins {
@@ -19,8 +33,8 @@ android {
         applicationId = "com.soreverse.mcp"
         minSdk = 26
         targetSdk = 36
-        versionCode = 19
-        versionName = "1.0.18"
+        versionCode = 20
+        versionName = "1.0.19"
 
         externalNativeBuild {
             cmake {


### PR DESCRIPTION
将应用版本升级到 1.0.19。

- `app/build.gradle.kts`：`versionCode` 19 → 20，`versionName` 1.0.18 → 1.0.19；并为该脚本文件补充 GPL-3.0 许可证头。
- `README.md`：更新当前版本号与按 ABI 举例的 APK 文件名（1.0.18 → 1.0.19）。