### PR TITLE
fix(ci): build keystone as shared lib to fix release failure

### DIFF
--- a/build-unidbg-native.sh
+++ b/build-unidbg-native.sh
@@ -217,7 +217,7 @@ fi
 
 if [[ $SKIP_KEYSTONE -eq 0 ]]; then
   build_one keystone "$PROJECT/third_party/keystone-engine-src" \
-    -DBUILD_LIBS_ONLY=ON -DLLVM_BUILD_TOOLS=OFF
+    -DBUILD_SHARED_LIBS=ON -DBUILD_LIBS_ONLY=ON -DLLVM_BUILD_TOOLS=OFF
   cp "$BUILD_ROOT/keystone/libkeystone.so" "$JNI_LIBS/"
   echo "[unidbg-native] copied libkeystone.so -> $JNI_LIBS"
 fi


### PR DESCRIPTION
## 问题

Release workflow（runs 32494377732 / 32494378074，v1.0.19）在 `Build Unidbg native libs` 步骤失败：

```
cp: cannot stat '.../third_party/unidbg-native-build/arm64-v8a/keystone/libkeystone.so': No such file or directory
```

## 根因

`build-unidbg-native.sh` 构建 keystone 时未开启共享库选项。keystone 的 `add_library(keystone ...)` 由 `BUILD_SHARED_LIBS` 控制（默认 OFF），因此产出静态库 `libkeystone.a`，而脚本 `cp` 期望 `libkeystone.so`，导致整个 release 构建终止。

对比：capstone 显式传了 `CAPSTONE_BUILD_SHARED=ON`，unicorn 的 `UNICORN_BUILD_SHARED` 默认 ON，唯独 keystone 缺 `-DBUILD_SHARED_LIBS=ON`。

## 改动

- `build-unidbg-native.sh`：keystone 构建参数增加 `-DBUILD_SHARED_LIBS=ON`。

## 验证

- 本机以 host 工具链配置 keystone（`BUILD_SHARED_LIBS=ON`）验证产物为 `libkeystone.so`，符合脚本 `cp` 期望。
- 完整 Android 四 ABI 交叉编译由该 PR 触发的 Release workflow 验证。