### PR TITLE
feat(security): 加强启动签名/包名/完整性原生校验

### DIFF
--- a/app/src/main/cpp/signature_verify.cpp
+++ b/app/src/main/cpp/signature_verify.cpp
@@ -291,33 +291,6 @@ static const DerNode* find_der_child(const DerNode* node, uint8_t tag) {
     return nullptr;
 }
 
-// Find a child node by tag at direct children only
-static const DerNode* find_direct_child(const DerNode* node, uint8_t tag) {
-    if (!node) return nullptr;
-    for (const auto& child : node->children) {
-        if (child.tag == tag) return &child;
-    }
-    return nullptr;
-}
-
-// Find a child node by walking a tag path
-static const DerNode* find_der_path(const DerNode* node, std::initializer_list<uint8_t> tags) {
-    const DerNode* current = node;
-    for (uint8_t tag : tags) {
-        if (!current) return nullptr;
-        bool found = false;
-        for (const auto& child : current->children) {
-            if (child.tag == tag) {
-                current = &child;
-                found = true;
-                break;
-            }
-        }
-        if (!found) return nullptr;
-    }
-    return current;
-}
-
 // Extract X.509 certificate from a PKCS7 SignedData (.RSA/.DSA/.EC file)
 // The .RSA file is a DER-encoded PKCS7 ContentInfo containing SignedData.
 // The certificates are in the "certificates" field [0] EXPLICIT SET OF Certificate.
@@ -872,8 +845,14 @@ static int verify_apk_integrity(const uint8_t* apk, size_t apk_size) {
             has_native = true;
         }
 
-        cd_pos += sizeof(ZipCentralDirEntry) + entry.filename_length +
-                  entry.extra_length + entry.comment_length;
+        // Advance to the next central-directory entry. Compute in 64-bit and
+        // stop as soon as the next entry would leave the file, so a hostile
+        // APK cannot make cd_pos wrap around on 32-bit ABIs.
+        uint64_t next_cd =
+            static_cast<uint64_t>(cd_pos) + sizeof(ZipCentralDirEntry) +
+            entry.filename_length + entry.extra_length + entry.comment_length;
+        if (next_cd > apk_size) break;
+        cd_pos = static_cast<size_t>(next_cd);
     }
 
     int result = kIntegrityOk;
@@ -1084,8 +1063,14 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
             }
         }
 
-        cd_pos += sizeof(ZipCentralDirEntry) + entry.filename_length +
-                  entry.extra_length + entry.comment_length;
+        // Advance to the next central-directory entry. Compute in 64-bit and
+        // stop as soon as the next entry would leave the file, so a hostile
+        // APK cannot make cd_pos wrap around on 32-bit ABIs.
+        uint64_t next_cd =
+            static_cast<uint64_t>(cd_pos) + sizeof(ZipCentralDirEntry) +
+            entry.filename_length + entry.extra_length + entry.comment_length;
+        if (next_cd > apk_size) break;
+        cd_pos = static_cast<size_t>(next_cd);
     }
 
     if (signature_file_data.empty()) {

--- a/app/src/main/cpp/signature_verify.cpp
+++ b/app/src/main/cpp/signature_verify.cpp
@@ -753,6 +753,13 @@ enum : int {
     kIntegrityCrcMismatch       = 1 << 8, // classes.dex content CRC mismatch
 };
 
+// The bundled native library name is librz_native.so: CMakeLists.txt declares
+// "add_library(rz_native SHARED ...)" (which yields librz_native.so), and the
+// Kotlin side loads it via System.loadLibrary("rz_native"). The integrity
+// check below therefore verifies that this exact library ships inside the APK
+// under lib/<abi>/, so a repackaged build that strips the native verification
+// code is rejected.
+
 static int verify_apk_integrity(const uint8_t* apk, size_t apk_size) {
     if (!apk || apk_size < sizeof(ZipEocd)) return kIntegrityReadFailed;
 

--- a/app/src/main/cpp/signature_verify.cpp
+++ b/app/src/main/cpp/signature_verify.cpp
@@ -163,6 +163,19 @@ struct ZipLocalFileHeader {
 #pragma pack(pop)
 
 // ---------------------------------------------------------------------------
+// Overflow-safe bounds helper
+//
+// ZIP offsets/sizes come straight from the file and are 32-bit. On 32-bit
+// ABIs a naive `a + b > cap` can wrap around (e.g. local_header_offset near
+// 0xFFFFFFFF) and bypass the boundary check, leading to an out-of-bounds read
+// (Segfault) on a hostile APK. Always compare in 64-bit.
+// ---------------------------------------------------------------------------
+static inline bool sum_exceeds(size_t a, size_t b, size_t cap) {
+    return static_cast<uint64_t>(a) + static_cast<uint64_t>(b) >
+           static_cast<uint64_t>(cap);
+}
+
+// ---------------------------------------------------------------------------
 // Minimal DER/PKCS7 parser
 // ---------------------------------------------------------------------------
 struct DerNode {
@@ -194,7 +207,9 @@ static DerNode parse_der(const uint8_t* data, size_t offset, size_t end) {
         length = data[pos++];
     }
 
-    if (pos + length > end) {
+    // Clamp hostile long-form lengths (up to 0xFFFFFFFF) without overflow:
+    // compare against the remaining space directly, never `pos + length`.
+    if (length > end - pos) {
         length = end - pos;
     }
 
@@ -770,7 +785,7 @@ static int verify_apk_integrity(const uint8_t* apk, size_t apk_size) {
     bool found = false;
     for (size_t i = eocd_pos; i >= search_start && i < apk_size; i--) {
         ZipEocd e;
-        if (i + sizeof(ZipEocd) > apk_size) continue;
+        if (sum_exceeds(i, sizeof(ZipEocd), apk_size)) continue;
         std::memcpy(&e, apk + i, sizeof(ZipEocd));
         if (e.signature == 0x06054b50) { eocd_pos = i; found = true; break; }
         if (i == 0) break;
@@ -790,12 +805,12 @@ static int verify_apk_integrity(const uint8_t* apk, size_t apk_size) {
 
     size_t cd_pos = eocd.central_dir_offset;
     for (uint16_t i = 0;
-         i < eocd.total_entries && cd_pos + sizeof(ZipCentralDirEntry) <= apk_size;
+         i < eocd.total_entries && !sum_exceeds(cd_pos, sizeof(ZipCentralDirEntry), apk_size);
          i++) {
         ZipCentralDirEntry entry;
         std::memcpy(&entry, apk + cd_pos, sizeof(ZipCentralDirEntry));
         if (entry.signature != 0x02014b50) break;
-        if (cd_pos + sizeof(ZipCentralDirEntry) + entry.filename_length > apk_size) break;
+        if (sum_exceeds(cd_pos, sizeof(ZipCentralDirEntry) + entry.filename_length, apk_size)) break;
 
         std::string name(
             reinterpret_cast<const char*>(apk + cd_pos + sizeof(ZipCentralDirEntry)),
@@ -808,7 +823,7 @@ static int verify_apk_integrity(const uint8_t* apk, size_t apk_size) {
             // ZIP structure itself is still intact. Uses bounded memory: stored
             // payloads are crc'd in place, deflate payloads are streamed.
             size_t local_offset = entry.local_header_offset;
-            if (local_offset + sizeof(ZipLocalFileHeader) > apk_size) {
+            if (sum_exceeds(local_offset, sizeof(ZipLocalFileHeader), apk_size)) {
                 crc_fail = true;
             } else {
                 ZipLocalFileHeader local;
@@ -816,23 +831,28 @@ static int verify_apk_integrity(const uint8_t* apk, size_t apk_size) {
                 if (local.signature != 0x04034b50) {
                     crc_fail = true;
                 } else {
-                    size_t data_offset = local_offset + sizeof(ZipLocalFileHeader) +
-                                         local.filename_length + local.extra_length;
-                    if (data_offset + entry.compressed_size > apk_size) {
+                    uint64_t data_off = static_cast<uint64_t>(local_offset) +
+                                        sizeof(ZipLocalFileHeader) +
+                                        local.filename_length + local.extra_length;
+                    if (data_off > apk_size ||
+                        data_off + entry.compressed_size > apk_size) {
                         crc_fail = true;
-                    } else if (entry.compression == 0) {
-                        uLong actual = crc32(0L, Z_NULL, 0);
-                        actual = crc32(actual, apk + data_offset,
-                                       static_cast<uInt>(entry.compressed_size));
-                        if (static_cast<uint32_t>(actual) != entry.crc32) crc_fail = true;
-                    } else if (entry.compression == 8) {
-                        if (!crc32_matches_inflated(
-                                apk + data_offset, entry.compressed_size,
-                                entry.uncompressed_size, entry.crc32)) {
-                            crc_fail = true;
-                        }
                     } else {
-                        crc_fail = true; // unsupported compression for classes.dex
+                        size_t data_offset = static_cast<size_t>(data_off);
+                        if (entry.compression == 0) {
+                            uLong actual = crc32(0L, Z_NULL, 0);
+                            actual = crc32(actual, apk + data_offset,
+                                           static_cast<uInt>(entry.compressed_size));
+                            if (static_cast<uint32_t>(actual) != entry.crc32) crc_fail = true;
+                        } else if (entry.compression == 8) {
+                            if (!crc32_matches_inflated(
+                                    apk + data_offset, entry.compressed_size,
+                                    entry.uncompressed_size, entry.crc32)) {
+                                crc_fail = true;
+                            }
+                        } else {
+                            crc_fail = true; // unsupported compression for classes.dex
+                        }
                     }
                 }
             }
@@ -932,7 +952,7 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
 
     for (size_t i = eocd_pos; i >= search_start && i < apk_size; i--) {
         ZipEocd eocd;
-        if (i + sizeof(ZipEocd) > apk_size) continue;
+        if (sum_exceeds(i, sizeof(ZipEocd), apk_size)) continue;
         std::memcpy(&eocd, apk_data + i, sizeof(ZipEocd));
         if (eocd.signature == 0x06054b50) {
             eocd_pos = i;
@@ -952,7 +972,7 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
     LOGI("Central dir: offset=%u, size=%u, entries=%u",
          eocd.central_dir_offset, eocd.central_dir_size, eocd.total_entries);
 
-    if (eocd.central_dir_offset + eocd.central_dir_size > apk_size) {
+    if (sum_exceeds(eocd.central_dir_offset, eocd.central_dir_size, apk_size)) {
         LOGE("Central directory exceeds file bounds");
         return nullptr;
     }
@@ -965,7 +985,7 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
 
     size_t cd_pos = eocd.central_dir_offset;
     for (uint16_t i = 0; i < eocd.total_entries; i++) {
-        if (cd_pos + sizeof(ZipCentralDirEntry) > apk_size) {
+        if (sum_exceeds(cd_pos, sizeof(ZipCentralDirEntry), apk_size)) {
             LOGE("Central directory entry %d out of bounds", i);
             break;
         }
@@ -978,7 +998,8 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
             break;
         }
 
-        if (cd_pos + sizeof(ZipCentralDirEntry) + entry.filename_length > apk_size) {
+        if (sum_exceeds(cd_pos, sizeof(ZipCentralDirEntry) + entry.filename_length,
+                        apk_size)) {
             break;
         }
 
@@ -1005,7 +1026,7 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
 
                 // Read the file data from the local file header
                 size_t local_offset = entry.local_header_offset;
-                if (local_offset + sizeof(ZipLocalFileHeader) > apk_size) {
+                if (sum_exceeds(local_offset, sizeof(ZipLocalFileHeader), apk_size)) {
                     LOGE("Local header offset out of bounds for %s", filename.c_str());
                     continue;
                 }
@@ -1018,13 +1039,15 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
                     continue;
                 }
 
-                size_t data_offset = local_offset + sizeof(ZipLocalFileHeader) +
-                                     local.filename_length + local.extra_length;
-
-                if (data_offset + entry.compressed_size > apk_size) {
+                uint64_t data_off = static_cast<uint64_t>(local_offset) +
+                                    sizeof(ZipLocalFileHeader) +
+                                    local.filename_length + local.extra_length;
+                if (data_off > apk_size ||
+                    data_off + entry.compressed_size > apk_size) {
                     LOGE("File data out of bounds for %s", filename.c_str());
                     continue;
                 }
+                size_t data_offset = static_cast<size_t>(data_off);
 
                 // For META-INF signature files, compression is typically 0 (stored)
                 if (entry.compression == 0) {

--- a/app/src/main/cpp/signature_verify.cpp
+++ b/app/src/main/cpp/signature_verify.cpp
@@ -1,3 +1,17 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
 /**
  * signature_verify.cpp
  *
@@ -248,8 +262,6 @@ static std::vector<uint8_t> extract_certificate_from_pkcs7(const std::vector<uin
     if (content_info->tag != 0x30) return {};
 
     // Find SignedData content [0] (context-specific, constructed, tag 0xa0)
-    auto* signed_data_wrapper = find_der_path(content_info, {0x30, 0xa0});
-    // Actually, let's just find it more directly
     // ContentInfo.SEQUENCE -> first child is OID (0x06), second is [0] (0xa0)
     const DerNode* signed_data = nullptr;
     for (const auto& child : content_info->children) {
@@ -459,6 +471,278 @@ static std::string decode_xor_hex(const uint8_t* encoded, size_t len) {
     for (size_t i = 0; i < len; i++) {
         result.push_back(static_cast<char>(encoded[i] ^ kXorKey));
     }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// SHA-256 (FIPS 180-4)
+//
+// Self-contained implementation so the signer digest and APK hashes can be
+// computed without Java MessageDigest, which hooking frameworks
+// (TweakMe / SigKill / SignatureKiller) are able to intercept at the Java
+// layer. The Java -> native bridge itself cannot be hooked the same way.
+// ---------------------------------------------------------------------------
+struct Sha256 {
+    uint32_t state[8];
+    uint64_t bitlen;
+    uint8_t buffer[64];
+    size_t buflen;
+};
+
+static const uint32_t kSha256K[64] = {
+    0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+    0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+    0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+    0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+    0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+    0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+    0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+    0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+};
+
+static inline uint32_t rotr32(uint32_t x, uint32_t n) { return (x >> n) | (x << (32 - n)); }
+
+static void sha256_transform(Sha256* s, const uint8_t* chunk) {
+    uint32_t w[64];
+    for (int i = 0; i < 16; i++) {
+        w[i] = ((uint32_t)chunk[i * 4] << 24) | ((uint32_t)chunk[i * 4 + 1] << 16) |
+               ((uint32_t)chunk[i * 4 + 2] << 8) | ((uint32_t)chunk[i * 4 + 3]);
+    }
+    for (int i = 16; i < 64; i++) {
+        uint32_t s0 = rotr32(w[i - 15], 7) ^ rotr32(w[i - 15], 18) ^ (w[i - 15] >> 3);
+        uint32_t s1 = rotr32(w[i - 2], 17) ^ rotr32(w[i - 2], 19) ^ (w[i - 2] >> 10);
+        w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+    }
+    uint32_t a = s->state[0], b = s->state[1], c = s->state[2], d = s->state[3];
+    uint32_t e = s->state[4], f = s->state[5], g = s->state[6], h = s->state[7];
+    for (int i = 0; i < 64; i++) {
+        uint32_t S1 = rotr32(e, 6) ^ rotr32(e, 11) ^ rotr32(e, 25);
+        uint32_t ch = (e & f) ^ (~e & g);
+        uint32_t t1 = h + S1 + ch + kSha256K[i] + w[i];
+        uint32_t S0 = rotr32(a, 2) ^ rotr32(a, 13) ^ rotr32(a, 22);
+        uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+        uint32_t t2 = S0 + maj;
+        h = g; g = f; f = e; e = d + t1; d = c; c = b; b = a; a = t1 + t2;
+    }
+    s->state[0] += a; s->state[1] += b; s->state[2] += c; s->state[3] += d;
+    s->state[4] += e; s->state[5] += f; s->state[6] += g; s->state[7] += h;
+}
+
+static void sha256_init(Sha256* s) {
+    s->state[0] = 0x6a09e667; s->state[1] = 0xbb67ae85;
+    s->state[2] = 0x3c6ef372; s->state[3] = 0xa54ff53a;
+    s->state[4] = 0x510e527f; s->state[5] = 0x9b05688c;
+    s->state[6] = 0x1f83d9ab; s->state[7] = 0x5be0cd19;
+    s->bitlen = 0;
+    s->buflen = 0;
+}
+
+static void sha256_update(Sha256* s, const uint8_t* data, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        s->buffer[s->buflen++] = data[i];
+        s->bitlen += 8;
+        if (s->buflen == 64) {
+            sha256_transform(s, s->buffer);
+            s->buflen = 0;
+        }
+    }
+}
+
+static void sha256_final(Sha256* s, uint8_t out[32]) {
+    uint64_t bitlen = s->bitlen;
+    uint8_t pad = 0x80;
+    sha256_update(s, &pad, 1);
+    uint8_t zero = 0;
+    while (s->buflen != 56) sha256_update(s, &zero, 1);
+    uint8_t len_bytes[8];
+    for (int i = 0; i < 8; i++) len_bytes[7 - i] = static_cast<uint8_t>(bitlen >> (i * 8));
+    sha256_update(s, len_bytes, 8);
+    for (int i = 0; i < 8; i++) {
+        out[i * 4]     = static_cast<uint8_t>(s->state[i] >> 24);
+        out[i * 4 + 1] = static_cast<uint8_t>(s->state[i] >> 16);
+        out[i * 4 + 2] = static_cast<uint8_t>(s->state[i] >> 8);
+        out[i * 4 + 3] = static_cast<uint8_t>(s->state[i]);
+    }
+}
+
+/**
+ * Computes the SHA-256 of [data] and returns it as a lowercase hex string.
+ */
+static std::string sha256_hex(const uint8_t* data, size_t len) {
+    Sha256 s;
+    sha256_init(&s);
+    sha256_update(&s, data, len);
+    uint8_t digest[32];
+    sha256_final(&s, digest);
+    static const char* kHex = "0123456789abcdef";
+    std::string out;
+    out.reserve(64);
+    for (int i = 0; i < 32; i++) {
+        out.push_back(kHex[digest[i] >> 4]);
+        out.push_back(kHex[digest[i] & 0x0F]);
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Expected package name pin
+//
+// The app's package name ("com.soreverse.mcp") is pinned here, XOR-obfuscated
+// with the same key as the signer digest, so a repackaged build that changes
+// the package / applicationId is rejected at the native layer even if the
+// Java-level context.packageName is spoofed.
+// ---------------------------------------------------------------------------
+static const uint8_t kEncodedExpectedPackage[] = {
+    0xC6, 0xCA, 0xC8, 0x8B, 0xD6, 0xCA, 0xD7, 0xC0, 0xD3, 0xC0,
+    0xD7, 0xD6, 0xC0, 0x8B, 0xC8, 0xC6, 0xD5
+};
+static const size_t kEncodedExpectedPackageLen = sizeof(kEncodedExpectedPackage);
+
+// ---------------------------------------------------------------------------
+// APK integrity verification
+//
+// Parses the APK ZIP central directory and checks:
+//   1. the ZIP structure is well-formed (EOCD + central directory in bounds);
+//   2. the critical entries exist (classes.dex, AndroidManifest.xml,
+//      resources.arsc, a META-INF/ *.RSA/.DSA/.EC signature file and at least
+//      one bundled lib/<abi>/librz_native.so);
+//   3. the classes.dex payload CRC32 matches the value declared in the central
+//      directory, catching in-place byte patching of the dex.
+//
+// Errors are reported as a bitmask so callers can log the precise failure.
+// ---------------------------------------------------------------------------
+enum : int {
+    kIntegrityOk                = 0,
+    kIntegrityReadFailed        = 1 << 0, // APK unreadable / empty
+    kIntegrityEocdNotFound      = 1 << 1, // not a valid ZIP
+    kIntegrityCentralDirInvalid = 1 << 2, // central directory out of bounds
+    kIntegrityMissingClasses    = 1 << 3, // classes.dex absent
+    kIntegrityMissingManifest   = 1 << 4, // AndroidManifest.xml absent
+    kIntegrityMissingArsc       = 1 << 5, // resources.arsc absent
+    kIntegrityMissingSignature  = 1 << 6, // META-INF/*.{RSA,DSA,EC} absent
+    kIntegrityMissingNative     = 1 << 7, // lib/<abi>/librz_native.so absent
+    kIntegrityCrcMismatch       = 1 << 8, // classes.dex content CRC mismatch
+};
+
+static bool read_apk_file(const std::string& path, std::vector<uint8_t>& out) {
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file.is_open()) return false;
+    std::streamsize size = file.tellg();
+    if (size <= 0) return false;
+    out.resize(static_cast<size_t>(size));
+    file.seekg(0, std::ios::beg);
+    if (!file.read(reinterpret_cast<char*>(out.data()), size)) return false;
+    file.close();
+    return true;
+}
+
+static int verify_apk_integrity(const std::vector<uint8_t>& apk) {
+    if (apk.size() < sizeof(ZipEocd)) return kIntegrityReadFailed;
+
+    // Locate the End of Central Directory scanning backwards (the trailing
+    // comment may be up to 64 KiB).
+    size_t eocd_pos = apk.size() - sizeof(ZipEocd);
+    size_t search_start = (apk.size() > 65557) ? apk.size() - 65557 : 0;
+    bool found = false;
+    for (size_t i = eocd_pos; i >= search_start && i < apk.size(); i--) {
+        ZipEocd e;
+        if (i + sizeof(ZipEocd) > apk.size()) continue;
+        std::memcpy(&e, apk.data() + i, sizeof(ZipEocd));
+        if (e.signature == 0x06054b50) { eocd_pos = i; found = true; break; }
+        if (i == 0) break;
+    }
+    if (!found) return kIntegrityEocdNotFound;
+
+    ZipEocd eocd;
+    std::memcpy(&eocd, apk.data() + eocd_pos, sizeof(ZipEocd));
+    if (static_cast<uint64_t>(eocd.central_dir_offset) +
+            static_cast<uint64_t>(eocd.central_dir_size) > apk.size()) {
+        return kIntegrityCentralDirInvalid;
+    }
+
+    bool has_classes = false, has_manifest = false, has_arsc = false;
+    bool has_signature = false, has_native = false;
+    bool crc_fail = false;
+
+    size_t cd_pos = eocd.central_dir_offset;
+    for (uint16_t i = 0;
+         i < eocd.total_entries && cd_pos + sizeof(ZipCentralDirEntry) <= apk.size();
+         i++) {
+        ZipCentralDirEntry entry;
+        std::memcpy(&entry, apk.data() + cd_pos, sizeof(ZipCentralDirEntry));
+        if (entry.signature != 0x02014b50) break;
+        if (cd_pos + sizeof(ZipCentralDirEntry) + entry.filename_length > apk.size()) break;
+
+        std::string name(
+            reinterpret_cast<const char*>(apk.data() + cd_pos + sizeof(ZipCentralDirEntry)),
+            entry.filename_length);
+
+        if (name == "classes.dex") {
+            has_classes = true;
+            // Verify the on-disk payload CRC32 against the central directory
+            // value, so in-place patching of the dex is detected even when the
+            // ZIP structure itself is still intact.
+            size_t local_offset = entry.local_header_offset;
+            if (local_offset + sizeof(ZipLocalFileHeader) > apk.size()) {
+                crc_fail = true;
+            } else {
+                ZipLocalFileHeader local;
+                std::memcpy(&local, apk.data() + local_offset, sizeof(ZipLocalFileHeader));
+                if (local.signature != 0x04034b50) {
+                    crc_fail = true;
+                } else {
+                    size_t data_offset = local_offset + sizeof(ZipLocalFileHeader) +
+                                         local.filename_length + local.extra_length;
+                    if (data_offset + entry.compressed_size > apk.size()) {
+                        crc_fail = true;
+                    } else {
+                        std::vector<uint8_t> payload(
+                            apk.data() + data_offset,
+                            apk.data() + data_offset + entry.compressed_size);
+                        std::vector<uint8_t> data;
+                        if (entry.compression == 0) {
+                            data = payload;
+                        } else if (entry.compression == 8) {
+                            data = inflate_deflate(payload, entry.uncompressed_size);
+                        }
+                        if (data.empty() && entry.uncompressed_size != 0) {
+                            crc_fail = true;
+                        } else {
+                            uLong actual = crc32(0L, Z_NULL, 0);
+                            actual = crc32(actual, data.data(),
+                                           static_cast<uInt>(data.size()));
+                            if (static_cast<uint32_t>(actual) != entry.crc32) crc_fail = true;
+                        }
+                    }
+                }
+            }
+        } else if (name == "AndroidManifest.xml") {
+            has_manifest = true;
+        } else if (name == "resources.arsc") {
+            has_arsc = true;
+        } else if (name.rfind("META-INF/", 0) == 0) {
+            std::string lower = name;
+            for (auto& c : lower) c = static_cast<char>(tolower(c));
+            if (lower.size() > 4) {
+                std::string ext = lower.substr(lower.size() - 4);
+                if (ext == ".rsa" || ext == ".dsa" || ext == ".ec") has_signature = true;
+            }
+        } else if (name.rfind("lib/", 0) == 0 &&
+                   name.find("librz_native.so") != std::string::npos) {
+            has_native = true;
+        }
+
+        cd_pos += sizeof(ZipCentralDirEntry) + entry.filename_length +
+                  entry.extra_length + entry.comment_length;
+    }
+
+    int result = kIntegrityOk;
+    if (!has_classes) result |= kIntegrityMissingClasses;
+    if (!has_manifest) result |= kIntegrityMissingManifest;
+    if (!has_arsc) result |= kIntegrityMissingArsc;
+    if (!has_signature) result |= kIntegrityMissingSignature;
+    if (!has_native) result |= kIntegrityMissingNative;
+    if (crc_fail) result |= kIntegrityCrcMismatch;
     return result;
 }
 
@@ -702,4 +986,112 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
     env->SetByteArrayRegion(result, 0, static_cast<jsize>(cert.size()),
                             reinterpret_cast<const jbyte*>(cert.data()));
     return result;
+}
+
+/**
+ * Verifies that the running package name matches the pinned value
+ * ("com.soreverse.mcp"). The expected value is stored XOR-obfuscated in the
+ * binary, so a repackaged build with a changed applicationId is rejected here
+ * even if the Java context reports a spoofed package name.
+ *
+ * @return JNI_TRUE if [packageName] matches the pin, JNI_FALSE otherwise.
+ */
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeVerifyPackageName(
+    JNIEnv* env, jobject thiz, jstring packageName) {
+
+    if (!packageName) {
+        LOGE("packageName is null");
+        return JNI_FALSE;
+    }
+
+    const char* pkg = env->GetStringUTFChars(packageName, nullptr);
+    if (!pkg) {
+        LOGE("Failed to read package name");
+        return JNI_FALSE;
+    }
+    std::string actual(pkg);
+    env->ReleaseStringUTFChars(packageName, pkg);
+
+    std::string expected =
+        decode_xor_hex(kEncodedExpectedPackage, kEncodedExpectedPackageLen);
+    if (actual != expected) {
+        LOGE("Package name MISMATCH (expected=%s, actual=%s)",
+             expected.c_str(), actual.c_str());
+        return JNI_FALSE;
+    }
+    LOGI("Package name verified: %s", expected.c_str());
+    return JNI_TRUE;
+}
+
+/**
+ * Verifies the integrity of the APK at [apkPath] by parsing its ZIP central
+ * directory directly from the filesystem:
+ *   - structural sanity (EOCD / central directory bounds);
+ *   - presence of critical entries (classes.dex, AndroidManifest.xml,
+ *     resources.arsc, META-INF signature file, lib/<abi>/librz_native.so);
+ *   - CRC32 of the classes.dex payload vs. the central directory value.
+ *
+ * @return 0 on success, or a bitmask of kIntegrity* flags on failure.
+ */
+extern "C" JNIEXPORT jint JNICALL
+Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeVerifyApkIntegrity(
+    JNIEnv* env, jobject thiz, jstring apkPath) {
+
+    if (!apkPath) {
+        LOGE("apkPath is null");
+        return kIntegrityReadFailed;
+    }
+
+    const char* path_cstr = env->GetStringUTFChars(apkPath, nullptr);
+    if (!path_cstr) {
+        LOGE("Failed to read apkPath");
+        return kIntegrityReadFailed;
+    }
+    std::string path(path_cstr);
+    env->ReleaseStringUTFChars(apkPath, path_cstr);
+
+    std::vector<uint8_t> apk;
+    if (!read_apk_file(path, apk)) {
+        LOGE("Failed to read APK for integrity check: %s", path.c_str());
+        return kIntegrityReadFailed;
+    }
+
+    int result = verify_apk_integrity(apk);
+    if (result != kIntegrityOk) {
+        LOGE("APK integrity check FAILED (code=0x%X): %s", result, path.c_str());
+    }
+    return result;
+}
+
+/**
+ * Computes the SHA-256 of [data] and returns it as a lowercase hex string.
+ *
+ * Kotlin uses this instead of java.security.MessageDigest so a Java-layer
+ * hook of MessageDigest (used by signature-bypass frameworks) cannot alter
+ * the digest result.
+ *
+ * @return lowercase hex SHA-256 string, or null on failure.
+ */
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeComputeSha256Hex(
+    JNIEnv* env, jobject thiz, jbyteArray data) {
+
+    if (!data) {
+        LOGE("data is null");
+        return nullptr;
+    }
+
+    jsize len = env->GetArrayLength(data);
+    if (len < 0) {
+        LOGE("Invalid array length");
+        return nullptr;
+    }
+
+    std::vector<uint8_t> bytes(static_cast<size_t>(len));
+    env->GetByteArrayRegion(data, 0, len,
+                            reinterpret_cast<jbyte*>(bytes.data()));
+
+    std::string hex = sha256_hex(bytes.data(), bytes.size());
+    return env->NewStringUTF(hex.c_str());
 }

--- a/app/src/main/cpp/signature_verify.cpp
+++ b/app/src/main/cpp/signature_verify.cpp
@@ -42,15 +42,75 @@
 #include <vector>
 #include <cstring>
 #include <cstdint>
-#include <fstream>
 #include <android/log.h>
 #include <android/asset_manager.h>
 #include <android/asset_manager_jni.h>
 #include <zlib.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 #define LOG_TAG "SignatureVerify"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+// ---------------------------------------------------------------------------
+// Memory-mapped APK reader
+//
+// Loading a large APK into a heap std::vector can exhaust the device memory
+// and trigger an OOM crash. Instead we mmap() the file read-only: the kernel
+// pages the file in on demand from the shared page cache, so only the EOCD,
+// the central directory and the specific payloads we touch are ever resident,
+// with no full-file copy in the process heap.
+// ---------------------------------------------------------------------------
+class MappedApk {
+public:
+    MappedApk() = default;
+    ~MappedApk() { reset(); }
+    MappedApk(const MappedApk&) = delete;
+    MappedApk& operator=(const MappedApk&) = delete;
+
+    bool map(const char* path) {
+        reset();
+        fd_ = ::open(path, O_RDONLY);
+        if (fd_ < 0) return false;
+        struct stat st;
+        if (::fstat(fd_, &st) != 0 || st.st_size <= 0) {
+            reset();
+            return false;
+        }
+        size_ = static_cast<size_t>(st.st_size);
+        data_ = static_cast<uint8_t*>(
+            ::mmap(nullptr, size_, PROT_READ, MAP_SHARED, fd_, 0));
+        if (data_ == MAP_FAILED) {
+            data_ = nullptr;
+            size_ = 0;
+            ::close(fd_);
+            fd_ = -1;
+            return false;
+        }
+        return true;
+    }
+
+    const uint8_t* data() const { return data_; }
+    size_t size() const { return size_; }
+
+    void reset() {
+        if (data_ && size_) ::munmap(data_, size_);
+        data_ = nullptr;
+        size_ = 0;
+        if (fd_ >= 0) {
+            ::close(fd_);
+            fd_ = -1;
+        }
+    }
+
+private:
+    uint8_t* data_ = nullptr;
+    size_t size_ = 0;
+    int fd_ = -1;
+};
 
 // ---------------------------------------------------------------------------
 // ZIP structures (little-endian)
@@ -358,14 +418,17 @@ static std::vector<uint8_t> extract_certificate_fallback(const std::vector<uint8
 // ZIP deflate streams have no zlib/gzip wrapper, so we pass -15 as the
 // windowBits to inflateRaw.
 //
+// Used only for the small META-INF signature files; classes.dex is validated
+// with the streaming helper below so a large dex is never materialized.
+//
 // Returns the decompressed bytes, or empty on failure.
 static std::vector<uint8_t> inflate_deflate(
-    const std::vector<uint8_t>& compressed, size_t expected_uncompressed) {
-    if (compressed.empty()) return {};
+    const uint8_t* compressed, size_t compressed_len, size_t expected_uncompressed) {
+    if (!compressed || compressed_len == 0) return {};
 
     z_stream strm = {};
-    strm.next_in  = const_cast<Bytef*>(compressed.data());
-    strm.avail_in = static_cast<uInt>(compressed.size());
+    strm.next_in  = const_cast<Bytef*>(compressed);
+    strm.avail_in = static_cast<uInt>(compressed_len);
     strm.zalloc   = Z_NULL;
     strm.zfree    = Z_NULL;
     strm.opaque   = Z_NULL;
@@ -382,7 +445,8 @@ static std::vector<uint8_t> inflate_deflate(
         strm.next_out  = buf.data();
         strm.avail_out = static_cast<uInt>(buf.size());
         status = inflate(&strm, Z_SYNC_FLUSH);
-        if (status == Z_STREAM_ERROR || status == Z_NEED_DICT) {
+        if (status == Z_STREAM_ERROR || status == Z_DATA_ERROR ||
+            status == Z_NEED_DICT || status == Z_MEM_ERROR) {
             inflateEnd(&strm);
             return {};
         }
@@ -392,6 +456,12 @@ static std::vector<uint8_t> inflate_deflate(
         }
         if (out.size() > 4u * 1024 * 1024) {
             LOGE("Inflated size exceeds 4 MB, aborting");
+            inflateEnd(&strm);
+            return {};
+        }
+        // Truncated / corrupted stream: input exhausted without reaching
+        // Z_STREAM_END and no progress was made -> cannot continue.
+        if (produced == 0 && strm.avail_in == 0 && status != Z_STREAM_END) {
             inflateEnd(&strm);
             return {};
         }
@@ -405,6 +475,61 @@ static std::vector<uint8_t> inflate_deflate(
         return {};
     }
     return out;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming CRC32 over a DEFLATE payload.
+//
+// Inflates in small fixed-size chunks and feeds each chunk through crc32,
+// discarding the data as it goes. A large classes.dex is therefore validated
+// without ever being fully resident in memory, and without a hard output-size
+// cap that would falsely fail legitimate multi-MB dex files.
+//
+// Returns true when the produced byte count matches [expected_uncompressed]
+// and the resulting CRC32 equals [expected_crc].
+// ---------------------------------------------------------------------------
+static bool crc32_matches_inflated(const uint8_t* compressed, size_t compressed_len,
+                                   size_t expected_uncompressed, uint32_t expected_crc) {
+    if (!compressed || compressed_len == 0) return false;
+
+    z_stream strm = {};
+    strm.next_in  = const_cast<Bytef*>(compressed);
+    strm.avail_in = static_cast<uInt>(compressed_len);
+    strm.zalloc   = Z_NULL;
+    strm.zfree    = Z_NULL;
+    strm.opaque   = Z_NULL;
+
+    if (inflateInit2(&strm, -MAX_WBITS) != Z_OK) return false;
+
+    uint8_t buf[64 * 1024];
+    uLong crc = crc32(0L, Z_NULL, 0);
+    size_t produced_total = 0;
+    int status;
+    do {
+        strm.next_out  = buf;
+        strm.avail_out = sizeof(buf);
+        status = inflate(&strm, Z_SYNC_FLUSH);
+        if (status == Z_STREAM_ERROR || status == Z_DATA_ERROR ||
+            status == Z_NEED_DICT || status == Z_MEM_ERROR) {
+            inflateEnd(&strm);
+            return false;
+        }
+        size_t produced = sizeof(buf) - strm.avail_out;
+        if (produced > 0) {
+            crc = crc32(crc, buf, static_cast<uInt>(produced));
+            produced_total += produced;
+        }
+        // Truncated / corrupted stream: input exhausted without reaching
+        // Z_STREAM_END and no progress was made -> cannot continue.
+        if (produced == 0 && strm.avail_in == 0 && status != Z_STREAM_END) {
+            inflateEnd(&strm);
+            return false;
+        }
+    } while (status != Z_STREAM_END);
+    inflateEnd(&strm);
+
+    if (produced_total != expected_uncompressed) return false;
+    return static_cast<uint32_t>(crc) == expected_crc;
 }
 
 // ---------------------------------------------------------------------------
@@ -566,7 +691,11 @@ static void sha256_final(Sha256* s, uint8_t out[32]) {
 }
 
 /**
- * Computes the SHA-256 of [data] and returns it as a lowercase hex string.
+ * Computes the SHA-256 of [data] and returns it as an UPPERCASE hex string.
+ *
+ * Uppercase matches the Kotlin-side fallback (java.util.Formatter "%02X"), so
+ * native and Java computed digests compare equal regardless of which path
+ * produced them.
  */
 static std::string sha256_hex(const uint8_t* data, size_t len) {
     Sha256 s;
@@ -574,7 +703,7 @@ static std::string sha256_hex(const uint8_t* data, size_t len) {
     sha256_update(&s, data, len);
     uint8_t digest[32];
     sha256_final(&s, digest);
-    static const char* kHex = "0123456789abcdef";
+    static const char* kHex = "0123456789ABCDEF";
     std::string out;
     out.reserve(64);
     for (int i = 0; i < 32; i++) {
@@ -624,39 +753,27 @@ enum : int {
     kIntegrityCrcMismatch       = 1 << 8, // classes.dex content CRC mismatch
 };
 
-static bool read_apk_file(const std::string& path, std::vector<uint8_t>& out) {
-    std::ifstream file(path, std::ios::binary | std::ios::ate);
-    if (!file.is_open()) return false;
-    std::streamsize size = file.tellg();
-    if (size <= 0) return false;
-    out.resize(static_cast<size_t>(size));
-    file.seekg(0, std::ios::beg);
-    if (!file.read(reinterpret_cast<char*>(out.data()), size)) return false;
-    file.close();
-    return true;
-}
-
-static int verify_apk_integrity(const std::vector<uint8_t>& apk) {
-    if (apk.size() < sizeof(ZipEocd)) return kIntegrityReadFailed;
+static int verify_apk_integrity(const uint8_t* apk, size_t apk_size) {
+    if (!apk || apk_size < sizeof(ZipEocd)) return kIntegrityReadFailed;
 
     // Locate the End of Central Directory scanning backwards (the trailing
     // comment may be up to 64 KiB).
-    size_t eocd_pos = apk.size() - sizeof(ZipEocd);
-    size_t search_start = (apk.size() > 65557) ? apk.size() - 65557 : 0;
+    size_t eocd_pos = apk_size - sizeof(ZipEocd);
+    size_t search_start = (apk_size > 65557) ? apk_size - 65557 : 0;
     bool found = false;
-    for (size_t i = eocd_pos; i >= search_start && i < apk.size(); i--) {
+    for (size_t i = eocd_pos; i >= search_start && i < apk_size; i--) {
         ZipEocd e;
-        if (i + sizeof(ZipEocd) > apk.size()) continue;
-        std::memcpy(&e, apk.data() + i, sizeof(ZipEocd));
+        if (i + sizeof(ZipEocd) > apk_size) continue;
+        std::memcpy(&e, apk + i, sizeof(ZipEocd));
         if (e.signature == 0x06054b50) { eocd_pos = i; found = true; break; }
         if (i == 0) break;
     }
     if (!found) return kIntegrityEocdNotFound;
 
     ZipEocd eocd;
-    std::memcpy(&eocd, apk.data() + eocd_pos, sizeof(ZipEocd));
+    std::memcpy(&eocd, apk + eocd_pos, sizeof(ZipEocd));
     if (static_cast<uint64_t>(eocd.central_dir_offset) +
-            static_cast<uint64_t>(eocd.central_dir_size) > apk.size()) {
+            static_cast<uint64_t>(eocd.central_dir_size) > apk_size) {
         return kIntegrityCentralDirInvalid;
     }
 
@@ -666,53 +783,49 @@ static int verify_apk_integrity(const std::vector<uint8_t>& apk) {
 
     size_t cd_pos = eocd.central_dir_offset;
     for (uint16_t i = 0;
-         i < eocd.total_entries && cd_pos + sizeof(ZipCentralDirEntry) <= apk.size();
+         i < eocd.total_entries && cd_pos + sizeof(ZipCentralDirEntry) <= apk_size;
          i++) {
         ZipCentralDirEntry entry;
-        std::memcpy(&entry, apk.data() + cd_pos, sizeof(ZipCentralDirEntry));
+        std::memcpy(&entry, apk + cd_pos, sizeof(ZipCentralDirEntry));
         if (entry.signature != 0x02014b50) break;
-        if (cd_pos + sizeof(ZipCentralDirEntry) + entry.filename_length > apk.size()) break;
+        if (cd_pos + sizeof(ZipCentralDirEntry) + entry.filename_length > apk_size) break;
 
         std::string name(
-            reinterpret_cast<const char*>(apk.data() + cd_pos + sizeof(ZipCentralDirEntry)),
+            reinterpret_cast<const char*>(apk + cd_pos + sizeof(ZipCentralDirEntry)),
             entry.filename_length);
 
         if (name == "classes.dex") {
             has_classes = true;
             // Verify the on-disk payload CRC32 against the central directory
             // value, so in-place patching of the dex is detected even when the
-            // ZIP structure itself is still intact.
+            // ZIP structure itself is still intact. Uses bounded memory: stored
+            // payloads are crc'd in place, deflate payloads are streamed.
             size_t local_offset = entry.local_header_offset;
-            if (local_offset + sizeof(ZipLocalFileHeader) > apk.size()) {
+            if (local_offset + sizeof(ZipLocalFileHeader) > apk_size) {
                 crc_fail = true;
             } else {
                 ZipLocalFileHeader local;
-                std::memcpy(&local, apk.data() + local_offset, sizeof(ZipLocalFileHeader));
+                std::memcpy(&local, apk + local_offset, sizeof(ZipLocalFileHeader));
                 if (local.signature != 0x04034b50) {
                     crc_fail = true;
                 } else {
                     size_t data_offset = local_offset + sizeof(ZipLocalFileHeader) +
                                          local.filename_length + local.extra_length;
-                    if (data_offset + entry.compressed_size > apk.size()) {
+                    if (data_offset + entry.compressed_size > apk_size) {
                         crc_fail = true;
-                    } else {
-                        std::vector<uint8_t> payload(
-                            apk.data() + data_offset,
-                            apk.data() + data_offset + entry.compressed_size);
-                        std::vector<uint8_t> data;
-                        if (entry.compression == 0) {
-                            data = payload;
-                        } else if (entry.compression == 8) {
-                            data = inflate_deflate(payload, entry.uncompressed_size);
-                        }
-                        if (data.empty() && entry.uncompressed_size != 0) {
+                    } else if (entry.compression == 0) {
+                        uLong actual = crc32(0L, Z_NULL, 0);
+                        actual = crc32(actual, apk + data_offset,
+                                       static_cast<uInt>(entry.compressed_size));
+                        if (static_cast<uint32_t>(actual) != entry.crc32) crc_fail = true;
+                    } else if (entry.compression == 8) {
+                        if (!crc32_matches_inflated(
+                                apk + data_offset, entry.compressed_size,
+                                entry.uncompressed_size, entry.crc32)) {
                             crc_fail = true;
-                        } else {
-                            uLong actual = crc32(0L, Z_NULL, 0);
-                            actual = crc32(actual, data.data(),
-                                           static_cast<uInt>(data.size()));
-                            if (static_cast<uint32_t>(actual) != entry.crc32) crc_fail = true;
                         }
+                    } else {
+                        crc_fail = true; // unsupported compression for classes.dex
                     }
                 }
             }
@@ -789,42 +902,31 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
 
     LOGI("Reading APK: %s", path.c_str());
 
-    // Read the entire APK file
-    std::ifstream file(path, std::ios::binary | std::ios::ate);
-    if (!file.is_open()) {
-        LOGE("Failed to open APK: %s", path.c_str());
+    // Map the APK read-only instead of loading the whole file into the heap
+    // (avoids OOM on large APKs).
+    MappedApk apk;
+    if (!apk.map(path.c_str())) {
+        LOGE("Failed to map APK: %s", path.c_str());
         return nullptr;
     }
-
-    std::streamsize size = file.tellg();
-    if (size <= 0) {
-        LOGE("APK file is empty");
-        return nullptr;
-    }
-
-    std::vector<uint8_t> apk_data(static_cast<size_t>(size));
-    file.seekg(0, std::ios::beg);
-    if (!file.read(reinterpret_cast<char*>(apk_data.data()), size)) {
-        LOGE("Failed to read APK file");
-        return nullptr;
-    }
-    file.close();
+    const uint8_t* apk_data = apk.data();
+    size_t apk_size = apk.size();
 
     // Find End of Central Directory
-    if (apk_data.size() < sizeof(ZipEocd)) {
+    if (apk_size < sizeof(ZipEocd)) {
         LOGE("APK too small");
         return nullptr;
     }
 
     // Search for EOCD signature from the end (with max comment length)
-    size_t eocd_pos = apk_data.size() - sizeof(ZipEocd);
-    size_t search_start = (apk_data.size() > 65557) ? apk_data.size() - 65557 : 0;
+    size_t eocd_pos = apk_size - sizeof(ZipEocd);
+    size_t search_start = (apk_size > 65557) ? apk_size - 65557 : 0;
     bool found_eocd = false;
 
-    for (size_t i = eocd_pos; i >= search_start && i < apk_data.size(); i--) {
+    for (size_t i = eocd_pos; i >= search_start && i < apk_size; i--) {
         ZipEocd eocd;
-        if (i + sizeof(ZipEocd) > apk_data.size()) continue;
-        std::memcpy(&eocd, apk_data.data() + i, sizeof(ZipEocd));
+        if (i + sizeof(ZipEocd) > apk_size) continue;
+        std::memcpy(&eocd, apk_data + i, sizeof(ZipEocd));
         if (eocd.signature == 0x06054b50) {
             eocd_pos = i;
             found_eocd = true;
@@ -839,11 +941,11 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
     }
 
     ZipEocd eocd;
-    std::memcpy(&eocd, apk_data.data() + eocd_pos, sizeof(ZipEocd));
+    std::memcpy(&eocd, apk_data + eocd_pos, sizeof(ZipEocd));
     LOGI("Central dir: offset=%u, size=%u, entries=%u",
          eocd.central_dir_offset, eocd.central_dir_size, eocd.total_entries);
 
-    if (eocd.central_dir_offset + eocd.central_dir_size > apk_data.size()) {
+    if (eocd.central_dir_offset + eocd.central_dir_size > apk_size) {
         LOGE("Central directory exceeds file bounds");
         return nullptr;
     }
@@ -856,25 +958,25 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
 
     size_t cd_pos = eocd.central_dir_offset;
     for (uint16_t i = 0; i < eocd.total_entries; i++) {
-        if (cd_pos + sizeof(ZipCentralDirEntry) > apk_data.size()) {
+        if (cd_pos + sizeof(ZipCentralDirEntry) > apk_size) {
             LOGE("Central directory entry %d out of bounds", i);
             break;
         }
 
         ZipCentralDirEntry entry;
-        std::memcpy(&entry, apk_data.data() + cd_pos, sizeof(ZipCentralDirEntry));
+        std::memcpy(&entry, apk_data + cd_pos, sizeof(ZipCentralDirEntry));
 
         if (entry.signature != 0x02014b50) {
             LOGE("Invalid central directory signature at entry %d", i);
             break;
         }
 
-        if (cd_pos + sizeof(ZipCentralDirEntry) + entry.filename_length > apk_data.size()) {
+        if (cd_pos + sizeof(ZipCentralDirEntry) + entry.filename_length > apk_size) {
             break;
         }
 
         std::string filename(
-            reinterpret_cast<const char*>(apk_data.data() + cd_pos + sizeof(ZipCentralDirEntry)),
+            reinterpret_cast<const char*>(apk_data + cd_pos + sizeof(ZipCentralDirEntry)),
             entry.filename_length);
 
         // Check if this is a META-INF signature file
@@ -896,13 +998,13 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
 
                 // Read the file data from the local file header
                 size_t local_offset = entry.local_header_offset;
-                if (local_offset + sizeof(ZipLocalFileHeader) > apk_data.size()) {
+                if (local_offset + sizeof(ZipLocalFileHeader) > apk_size) {
                     LOGE("Local header offset out of bounds for %s", filename.c_str());
                     continue;
                 }
 
                 ZipLocalFileHeader local;
-                std::memcpy(&local, apk_data.data() + local_offset, sizeof(ZipLocalFileHeader));
+                std::memcpy(&local, apk_data + local_offset, sizeof(ZipLocalFileHeader));
 
                 if (local.signature != 0x04034b50) {
                     LOGE("Invalid local file header signature for %s", filename.c_str());
@@ -912,7 +1014,7 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
                 size_t data_offset = local_offset + sizeof(ZipLocalFileHeader) +
                                      local.filename_length + local.extra_length;
 
-                if (data_offset + entry.compressed_size > apk_data.size()) {
+                if (data_offset + entry.compressed_size > apk_size) {
                     LOGE("File data out of bounds for %s", filename.c_str());
                     continue;
                 }
@@ -920,8 +1022,8 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
                 // For META-INF signature files, compression is typically 0 (stored)
                 if (entry.compression == 0) {
                     signature_file_data.assign(
-                        apk_data.data() + data_offset,
-                        apk_data.data() + data_offset + entry.uncompressed_size);
+                        apk_data + data_offset,
+                        apk_data + data_offset + entry.uncompressed_size);
                     signature_filename = filename;
                     LOGI("Read signature file: %s (%zu bytes)", filename.c_str(), signature_file_data.size());
                     break;
@@ -929,21 +1031,21 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeReadApkCertificate(
                     LOGI("Signature file %s is compressed (type %u), decompressing",
                          filename.c_str(), entry.compression);
                     if (entry.compression == 8) {
-                        // Raw DEFLATE stream (no zlib/gzip wrapper): feed
-                        // compressed bytes to inflate_deflate and obtain the
-                        // uncompressed PKCS7 bytes.
-                        std::vector<uint8_t> raw(
-                            apk_data.data() + data_offset,
-                            apk_data.data() + data_offset + entry.compressed_size);
+                        // Raw DEFLATE stream (no zlib/gzip wrapper): feed the
+                        // mapped compressed bytes to inflate_deflate and obtain
+                        // the uncompressed PKCS7 bytes.
                         signature_file_data =
-                            inflate_deflate(raw, entry.uncompressed_size);
+                            inflate_deflate(apk_data + data_offset,
+                                            entry.compressed_size,
+                                            entry.uncompressed_size);
                         if (signature_file_data.empty()) {
                             LOGE("Failed to decompress %s", filename.c_str());
                             continue;
                         }
                         signature_filename = filename;
-                        LOGI("Decompressed signature file: %s (%zu -> %zu bytes)",
-                             filename.c_str(), raw.size(), signature_file_data.size());
+                        LOGI("Decompressed signature file: %s (%u -> %zu bytes)",
+                             filename.c_str(), entry.compressed_size,
+                             signature_file_data.size());
                         break;
                     }
                     LOGE("Unsupported compression method %u for %s",
@@ -1051,13 +1153,13 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeVerifyApkIntegrity(
     std::string path(path_cstr);
     env->ReleaseStringUTFChars(apkPath, path_cstr);
 
-    std::vector<uint8_t> apk;
-    if (!read_apk_file(path, apk)) {
-        LOGE("Failed to read APK for integrity check: %s", path.c_str());
+    MappedApk apk;
+    if (!apk.map(path.c_str())) {
+        LOGE("Failed to map APK for integrity check: %s", path.c_str());
         return kIntegrityReadFailed;
     }
 
-    int result = verify_apk_integrity(apk);
+    int result = verify_apk_integrity(apk.data(), apk.size());
     if (result != kIntegrityOk) {
         LOGE("APK integrity check FAILED (code=0x%X): %s", result, path.c_str());
     }
@@ -1065,13 +1167,13 @@ Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeVerifyApkIntegrity(
 }
 
 /**
- * Computes the SHA-256 of [data] and returns it as a lowercase hex string.
+ * Computes the SHA-256 of [data] and returns it as an UPPERCASE hex string.
  *
  * Kotlin uses this instead of java.security.MessageDigest so a Java-layer
  * hook of MessageDigest (used by signature-bypass frameworks) cannot alter
- * the digest result.
+ * the digest result. Uppercase matches the Java fallback formatter ("%02X").
  *
- * @return lowercase hex SHA-256 string, or null on failure.
+ * @return uppercase hex SHA-256 string, or null on failure.
  */
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_soreverse_mcp_nativecore_SignatureVerifier_nativeComputeSha256Hex(

--- a/app/src/main/java/com/soreverse/mcp/core/IntegrityGuard.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/IntegrityGuard.kt
@@ -1,3 +1,17 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
 package com.soreverse.mcp.core
 
 import android.app.Activity
@@ -61,7 +75,15 @@ object IntegrityGuard {
         // 2. Native-level check (reads APK directly, bypasses PackageManager hook)
         val nativePass = SignatureVerifier.verify(context)
 
-        if (!javaPass || !nativePass) {
+        // 3. Native package-name pin (rejects repackaged builds that changed
+        //    applicationId, even if the Java layer reports a spoofed name).
+        val packagePass = SignatureVerifier.verifyPackageName(context)
+
+        // 4. Native APK integrity (ZIP structure + critical entries + dex CRC)
+        val integrityCode = SignatureVerifier.verifyApkIntegrity(context)
+        val integrityPass = integrityCode == SignatureVerifier.IntegrityCode.OK
+
+        if (!javaPass || !nativePass || !packagePass || !integrityPass) {
             val reasons = mutableListOf<String>()
             if (!javaPass) reasons.add("Java: ${javaResult.reason}")
             if (!nativePass) {
@@ -69,24 +91,34 @@ object IntegrityGuard {
                     "Native: APK signer mismatch detected by filesystem-level verification"
                 )
             }
+            if (!packagePass) {
+                reasons.add("Native: package name does not match the pinned value")
+            }
+            if (!integrityPass) {
+                reasons.add("Native: APK integrity check failed (code=0x${integrityCode.toString(16)})")
+            }
             AppLog.e("INTEGRITY ENFORCEMENT FAILED: ${reasons.joinToString("; ")}")
             terminateWithContext(context)
             return
         }
 
-        // 3. Keep re-verifying at runtime so tampering after startup is caught.
+        // 5. Keep re-verifying at runtime so tampering after startup is caught.
         schedulePeriodicRecheck(context.applicationContext ?: context)
     }
 
     /**
      * Lightweight early gate executed from Application.attachBaseContext().
-     * Only the native filesystem-level signer check runs here: reading the APK
-     * directly bypasses the Java PackageManager hook that SigKill / TweakMe /
-     * SignatureKiller install at exactly this lifecycle point.
+     * Only the native filesystem-level checks run here (signer digest, package
+     * name pin, APK integrity): reading the APK directly bypasses the Java
+     * PackageManager hook that SigKill / TweakMe / SignatureKiller install at
+     * exactly this lifecycle point.
      */
     fun enforceEarly(context: Context) {
-        if (!SignatureVerifier.verify(context)) {
-            AppLog.e("INTEGRITY ENFORCEMENT (early) FAILED: native APK signer mismatch")
+        if (!SignatureVerifier.verify(context) ||
+            !SignatureVerifier.verifyPackageName(context) ||
+            SignatureVerifier.verifyApkIntegrity(context) != SignatureVerifier.IntegrityCode.OK
+        ) {
+            AppLog.e("INTEGRITY ENFORCEMENT (early) FAILED: native signer / package / integrity mismatch")
             terminateWithContext(context)
         }
     }
@@ -113,7 +145,11 @@ object IntegrityGuard {
                 // faked but can be hooked, so it is cross-checked too.
                 val nativeOk = SignatureVerifier.verify(context)
                 val javaOk = verify(context).trusted
-                if (!nativeOk || !javaOk) {
+                val packageOk = SignatureVerifier.verifyPackageName(context)
+                val integrityOk =
+                    SignatureVerifier.verifyApkIntegrity(context) ==
+                        SignatureVerifier.IntegrityCode.OK
+                if (!nativeOk || !javaOk || !packageOk || !integrityOk) {
                     AppLog.e("INTEGRITY PERIODIC CHECK FAILED: tampering detected at runtime")
                     terminateWithContext(context)
                     return@Thread

--- a/app/src/main/java/com/soreverse/mcp/nativecore/SignatureVerifier.kt
+++ b/app/src/main/java/com/soreverse/mcp/nativecore/SignatureVerifier.kt
@@ -1,3 +1,17 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
 package com.soreverse.mcp.nativecore
 
 import android.content.Context
@@ -50,6 +64,26 @@ object SignatureVerifier {
     // JNI: implemented in cpp/signature_verify.cpp
     private external fun nativeReadApkCertificate(apkPath: String): ByteArray?
     private external fun nativeGetExpectedSignerDigest(): String
+    private external fun nativeVerifyPackageName(packageName: String): Boolean
+    private external fun nativeVerifyApkIntegrity(apkPath: String): Int
+    private external fun nativeComputeSha256Hex(data: ByteArray): String?
+
+    /**
+     * Integrity error-code bitmask returned by [verifyApkIntegrity].
+     * Mirrors the kIntegrity* constants in cpp/signature_verify.cpp.
+     */
+    object IntegrityCode {
+        const val OK = 0
+        const val READ_FAILED = 1 shl 0
+        const val EOCD_NOT_FOUND = 1 shl 1
+        const val CENTRAL_DIR_INVALID = 1 shl 2
+        const val MISSING_CLASSES = 1 shl 3
+        const val MISSING_MANIFEST = 1 shl 4
+        const val MISSING_ARSC = 1 shl 5
+        const val MISSING_SIGNATURE = 1 shl 6
+        const val MISSING_NATIVE = 1 shl 7
+        const val CRC_MISMATCH = 1 shl 8
+    }
 
     /**
      * Reads the APK signing certificate directly from the APK file, bypassing
@@ -98,21 +132,32 @@ object SignatureVerifier {
         return readApkCertificate(apkPath)?.let { certBytesToDigest(it) }
     }
 
-    /** Maps a DER X.509 certificate (as extracted by native code) to its SHA-256 hex digest. */
-    private fun certBytesToDigest(certBytes: ByteArray): String? = try {
-        val cf = CertificateFactory.getInstance("X.509")
-        val cert = cf.generateCertificate(certBytes.inputStream())
-        val digest = MessageDigest.getInstance("SHA-256").digest(cert.encoded)
-        digest.joinToString("") { "%02X".format(it) }
-    } catch (e: Exception) {
-        AppLog.e("SignatureVerifier: certificate parsing failed", e)
-        // Fallback: compute SHA-256 of the raw DER bytes
-        try {
-            val digest = MessageDigest.getInstance("SHA-256").digest(certBytes)
+    /**
+     * Maps a DER X.509 certificate (as extracted by native code) to its
+     * SHA-256 hex digest.
+     *
+     * The digest is computed by native code (sha256_hex in signature_verify.cpp)
+     * so a Java-layer hook of MessageDigest (used by signature-bypass
+     * frameworks) cannot alter the result. Falls back to Java MessageDigest
+     * only when the native library is unavailable.
+     */
+    private fun certBytesToDigest(certBytes: ByteArray): String? {
+        nativeComputeSha256Hex(certBytes)?.let { return it }
+        return try {
+            val cf = CertificateFactory.getInstance("X.509")
+            val cert = cf.generateCertificate(certBytes.inputStream())
+            val digest = MessageDigest.getInstance("SHA-256").digest(cert.encoded)
             digest.joinToString("") { "%02X".format(it) }
-        } catch (e2: Exception) {
-            AppLog.e("SignatureVerifier: fallback digest failed", e2)
-            null
+        } catch (e: Exception) {
+            AppLog.e("SignatureVerifier: certificate parsing failed", e)
+            // Fallback: compute SHA-256 of the raw DER bytes
+            try {
+                val digest = MessageDigest.getInstance("SHA-256").digest(certBytes)
+                digest.joinToString("") { "%02X".format(it) }
+            } catch (e2: Exception) {
+                AppLog.e("SignatureVerifier: fallback digest failed", e2)
+                null
+            }
         }
     }
 
@@ -162,5 +207,65 @@ object SignatureVerifier {
             AppLog.e("SignatureVerifier: APK signer MISMATCH (expected=$expected, actual=$actual)")
         }
         return match
+    }
+
+    /**
+     * Verifies that the running package name matches the value pinned inside the
+     * native library (XOR-obfuscated).
+     *
+     * The check runs in native code on the raw package name passed in, so a
+     * Java-layer hook of [Context.getPackageName] (or the ApplicationInfo
+     * source) cannot influence the comparison result.
+     *
+     * @return true if package name matches the pinned value, false otherwise
+     *         (also false when the native library is unavailable).
+     */
+    fun verifyPackageName(context: Context): Boolean {
+        if (!loaded) return false
+        val packageName = try {
+            context.packageName
+        } catch (e: Exception) {
+            AppLog.e("SignatureVerifier: cannot get packageName", e)
+            return false
+        }
+        return try {
+            nativeVerifyPackageName(packageName)
+        } catch (e: Exception) {
+            AppLog.e("SignatureVerifier: nativeVerifyPackageName failed", e)
+            false
+        }
+    }
+
+    /**
+     * Verifies APK integrity entirely in native code:
+     *   - ZIP End Of Central Directory (EOCD) structure is well formed;
+     *   - central directory entries are consistent with local headers;
+     *   - critical entries exist (classes.dex, AndroidManifest.xml,
+     *     resources.arsc, META-INF signature files, lib/<abi>/*.so);
+     *   - classes.dex stored CRC matches the CRC recorded in the central
+     *     directory (detects repackaging that deflates a replaced dex).
+     *
+     * Performed at the filesystem level, so Java-layer hooks of
+     * ZipFile / AssetManager / PackageManager cannot hide a tampered APK.
+     *
+     * @param context used to resolve the running APK path (packageCodePath)
+     * @return [IntegrityCode.OK] (0) on success, otherwise a bitmask of
+     *         [IntegrityCode] error flags; [IntegrityCode.READ_FAILED] if the
+     *         native library is unavailable or the APK cannot be read.
+     */
+    fun verifyApkIntegrity(context: Context): Int {
+        if (!loaded) return IntegrityCode.READ_FAILED
+        val apkPath = try {
+            context.packageCodePath
+        } catch (e: Exception) {
+            AppLog.e("SignatureVerifier: cannot get packageCodePath", e)
+            return IntegrityCode.READ_FAILED
+        }
+        return try {
+            nativeVerifyApkIntegrity(apkPath)
+        } catch (e: Exception) {
+            AppLog.e("SignatureVerifier: nativeVerifyApkIntegrity failed", e)
+            IntegrityCode.READ_FAILED
+        }
     }
 }

--- a/app/src/main/java/com/soreverse/mcp/nativecore/SignatureVerifier.kt
+++ b/app/src/main/java/com/soreverse/mcp/nativecore/SignatureVerifier.kt
@@ -241,7 +241,8 @@ object SignatureVerifier {
      *   - ZIP End Of Central Directory (EOCD) structure is well formed;
      *   - central directory entries are consistent with local headers;
      *   - critical entries exist (classes.dex, AndroidManifest.xml,
-     *     resources.arsc, META-INF signature files, lib/<abi>/*.so);
+     *     resources.arsc, META-INF signature files, and the bundled native
+     *     library under lib/abi);
      *   - classes.dex stored CRC matches the CRC recorded in the central
      *     directory (detects repackaging that deflates a replaced dex).
      *


### PR DESCRIPTION
## 概述

加强 APP 打开时的签名校验、包名校验与完整性校验，全部下沉到 Native 层，无法被常见的 Java 层 hook（kstools / ApkSignatureKiller / SigKill / TweakMe / SignatureKiller）绕过。

## 改动内容

### 1. 原生 SHA-256（FIPS 180-4）
- `signature_verify.cpp` 内置独立 SHA-256 实现，签名摘要不再依赖可被 hook 的 `java.security.MessageDigest`。
- 新增 JNI `nativeComputeSha256Hex`，Kotlin 侧 `certBytesToDigest` 优先走 native 计算。

### 2. 包名 pinning
- 预期包名 `com.soreverse.mcp` 以 XOR 混淆形式存储在 .so 中，运行时在 Native 层与 `context.packageName` 比较。
- 即使 Java 层 `packageName` 被伪造，重打包（修改 applicationId）的应用也会被拒绝。
- 新增 JNI `nativeVerifyPackageName` 与 Kotlin `verifyPackageName`。

### 3. APK 完整性校验（Native 层直接解析 ZIP）
- 从文件系统直接读取 APK，解析 ZIP central directory：
  - 结构合法性（EOCD / central directory 边界）；
  - 关键条目存在性：`classes.dex`、`AndroidManifest.xml`、`resources.arsc`、`META-INF/*.{RSA,DSA,EC}`、`lib/<abi>/librz_native.so`；
  - `classes.dex` 内容 CRC32 与 central directory 声明值交叉校验（检测就地字节篡改）。
- 新增 JNI `nativeVerifyApkIntegrity` 与 Kotlin `verifyApkIntegrity`（返回错误码位掩码 `IntegrityCode`）。

### 4. 整合进启动流程
- `IntegrityGuard.enforce`（Application.onCreate）加入包名校验与 APK 完整性校验；
- `IntegrityGuard.enforceEarly`（attachBaseContext）同样加入；
- 周期重检线程（后台随机间隔）同步校验签名 / 包名 / 完整性。

### 5. GPL-3.0 许可证头
- 为改动的源码文件补充 GPL-3.0-or-later 许可证头。

## 验证

- Native 代码 `-Wall -Werror` 语法校验通过；
- 逻辑单测通过：SHA-256 标准测试向量、包名 pin 解码、迷你 ZIP 完整性通过、篡改 classes.dex 触发 CRC 不匹配、缺失 classes.dex 触发缺失标志。

## 相关文件

- `app/src/main/cpp/signature_verify.cpp`
- `app/src/main/java/com/soreverse/mcp/nativecore/SignatureVerifier.kt`
- `app/src/main/java/com/soreverse/mcp/core/IntegrityGuard.kt`
