### PR TITLE
fix(release): copy libkeystone.so from its real output dir

### DIFF
--- a/build-unidbg-native.sh
+++ b/build-unidbg-native.sh
@@ -218,8 +218,19 @@ fi
 if [[ $SKIP_KEYSTONE -eq 0 ]]; then
   build_one keystone "$PROJECT/third_party/keystone-engine-src" \
     -DBUILD_SHARED_LIBS=ON -DBUILD_LIBS_ONLY=ON -DLLVM_BUILD_TOOLS=OFF
-  cp "$BUILD_ROOT/keystone/libkeystone.so" "$JNI_LIBS/"
-  echo "[unidbg-native] copied libkeystone.so -> $JNI_LIBS"
+  # keystone's bundled LLVM build redirects libkeystone.so into
+  # <build>/llvm/lib/ (LIBRARY_OUTPUT_DIRECTORY from its llvm CMake), not the
+  # build root; locate it defensively in case the layout changes upstream.
+  keystone_so="$BUILD_ROOT/keystone/llvm/lib/libkeystone.so"
+  if [[ ! -f "$keystone_so" ]]; then
+    keystone_so="$(find "$BUILD_ROOT/keystone" -name 'libkeystone.so' -print -quit || true)"
+  fi
+  if [[ -z "$keystone_so" || ! -f "$keystone_so" ]]; then
+    echo "error: libkeystone.so not found under $BUILD_ROOT/keystone" >&2
+    exit 1
+  fi
+  cp "$keystone_so" "$JNI_LIBS/"
+  echo "[unidbg-native] copied $(basename "$keystone_so") -> $JNI_LIBS"
 fi
 
 if [[ $SKIP_UNICORN -eq 0 ]]; then


### PR DESCRIPTION
修复 Release 1.0.19 构建失败（unidbg native libs 步骤）。

**根因**：keystone 内置 LLVM 的 CMake 将 `libkeystone.so` 重定向到 `<build>/llvm/lib/`（LIBRARY_OUTPUT_DIRECTORY），而非构建根目录；脚本仍从 `$BUILD_ROOT/keystone/libkeystone.so` 拷贝，导致 `cp: cannot stat ... libkeystone.so`。

**修复**：优先使用已知真实路径 `<build>/keystone/llvm/lib/libkeystone.so`，缺失时递归 find 兜底，定位后拷入 jniLibs。

**背景**：PR #38 已加 `-DBUILD_SHARED_LIBS=ON`，keystone 现已产出 `.so`（run 32515106237 日志确认 `Linking CXX shared library llvm/lib/libkeystone.so`），本 PR 补上真实拷贝路径。该 unidbg 步骤自引入（c7438aa）起从未成功。