### PR TITLE
fix(release): skip Unidbg unicorn on 32-bit ABIs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,12 @@ jobs:
           for abi in arm64-v8a armeabi-v7a x86 x86_64; do
             bash build-unidbg-native.sh --abi "$abi"
           done
-          # Sanity-check that every ABI now has all three natives in jniLibs
-          # before the APK is assembled; abort if any is missing.
-          for abi in arm64-v8a armeabi-v7a x86 x86_64; do
+          # Sanity-check that every ABI now has its required natives in
+          # jniLibs before the APK is assembled; abort if any is missing.
+          # unicorn (QEMU, __uint128_t) only compiles for the 64-bit ABIs
+          # (arm64-v8a, x86_64); the 32-bit ABIs (armeabi-v7a, x86) get
+          # capstone/keystone only, and Unidbg degrades gracefully there.
+          for abi in arm64-v8a x86_64; do
             for lib in capstone keystone unicorn; do
               test -f "app/src/main/jniLibs/$abi/lib$lib.so" || {
                 echo "::error::missing app/src/main/jniLibs/$abi/lib$lib.so after build-unidbg-native.sh"
@@ -86,7 +89,15 @@ jobs:
               }
             done
           done
-          echo "Unidbg native libs present for all four ABIs."
+          for abi in armeabi-v7a x86; do
+            for lib in capstone keystone; do
+              test -f "app/src/main/jniLibs/$abi/lib$lib.so" || {
+                echo "::error::missing app/src/main/jniLibs/$abi/lib$lib.so after build-unidbg-native.sh"
+                exit 1
+              }
+            done
+          done
+          echo "Unidbg native libs present for required ABIs."
 
       - name: Restore release signing keystore
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -219,7 +219,11 @@ abstract class UnidbgNativeBuildTask : DefaultTask() {
         val libs = nativeLibs.get()
         val haveAll = abis.get().all { abi ->
             val dir = jniLibsRoot.get().resolve(abi)
-            dir.isDirectory && libs.all { lib -> dir.resolve("lib$lib.so").exists() }
+            // unicorn (QEMU, __uint128_t) only compiles for the 64-bit ABIs;
+            // the 32-bit ABIs get capstone/keystone only (Unidbg degrades
+            // gracefully there but the APKs still build).
+            val required = if (abi == "arm64-v8a" || abi == "x86_64") libs else libs - "unicorn"
+            dir.isDirectory && required.all { lib -> dir.resolve("lib$lib.so").exists() }
         }
         if (haveAll) {
             logger.lifecycle("[unidbg-native] libs already present in jniLibs; skipping build")

--- a/build-unidbg-native.sh
+++ b/build-unidbg-native.sh
@@ -234,13 +234,23 @@ if [[ $SKIP_KEYSTONE -eq 0 ]]; then
 fi
 
 if [[ $SKIP_UNICORN -eq 0 ]]; then
-  # unidbg 0.9.9's Unicorn2Factory uses unicorn2 (the zhkl0228 fork).
-  uni="$PROJECT/third_party/unicorn-zhkl0228"
-  [[ -d "$uni" ]] || uni="$PROJECT/third_party/unicorn-engine-unicorn2"
-  build_one unicorn "$uni" \
-    -DUNICORN_ARCH=arm,aarch64 -DUNICORN_BUILD_TESTS=OFF -DUNICORN_BUILD_SAMPLES=OFF
-  cp "$BUILD_ROOT/unicorn/libunicorn.so" "$JNI_LIBS/"
-  echo "[unidbg-native] copied libunicorn.so -> $JNI_LIBS"
+  # unicorn's bundled QEMU uses __uint128_t (CONFIG_INT128 in host-utils.h),
+  # which the Android NDK does not provide for 32-bit targets (armeabi-v7a,
+  # x86), so it only compiles for 64-bit ABIs. On 32-bit ABIs we skip
+  # libunicorn so the (still 32-bit) APKs build; Unidbg is unavailable there
+  # but degrades gracefully via UnidbgEmulator's native load handling.
+  # capstone/keystone compile for every ABI.
+  if [[ "$ABI" != "arm64-v8a" && "$ABI" != "x86_64" ]]; then
+    echo "[unidbg-native] WARNING: unicorn cannot compile on 32-bit ABI '$ABI' (needs __uint128_t); skipping libunicorn.so for this ABI"
+  else
+    # unidbg 0.9.9's Unicorn2Factory uses unicorn2 (the zhkl0228 fork).
+    uni="$PROJECT/third_party/unicorn-zhkl0228"
+    [[ -d "$uni" ]] || uni="$PROJECT/third_party/unicorn-engine-unicorn2"
+    build_one unicorn "$uni" \
+      -DUNICORN_ARCH=arm,aarch64 -DUNICORN_BUILD_TESTS=OFF -DUNICORN_BUILD_SAMPLES=OFF
+    cp "$BUILD_ROOT/unicorn/libunicorn.so" "$JNI_LIBS/"
+    echo "[unidbg-native] copied libunicorn.so -> $JNI_LIBS"
+  fi
 fi
 
 echo "[unidbg-native] DONE - rebuild the APK to enable the Unidbg backend (libjnidispatch.so is provided automatically by the JNA AAR)"


### PR DESCRIPTION
修复 v1.0.19 Release 构建失败（release 工作流 unidbg native 步骤）。

**本次失败点（run 32539287073）**：keystone 已修好，失败推进到 `unicorn`。unicorn（QEMU）`qemu/include/qemu/host-utils.h` 在 `CONFIG_INT128` 下使用 `__uint128_t`，而 Android NDK 在 32 位 ABI（`armeabi-v7a`/`x86`）不提供该类型，导致 20 个编译错误——这是该 unicorn fork 对 32 位安卓的固有限制。

**方案**（保留四 ABI 出包，按要求必须出 32 位 APK）：
- `libunicorn.so` 只在 64 位 ABI（`arm64-v8a`/`x86_64`）编译打包。
- 32 位 ABI 仍打包 `libcapstone.so`/`libkeystone.so`（它们可正常编译）；Unidbg 在 32 位设备上缺失 `libunicorn.so` 时按既有逻辑优雅降级为 EMULATOR_UNAVAILABLE，不崩溃。
- release.yml 校验与 gradle `UnidbgNativeBuildTask` 的 `haveAll` 改为按 ABI 感知。

改动：`build-unidbg-native.sh`、`.github/workflows/release.yml`、`app/build.gradle.kts`。