### PR TITLE
fix(tunnel): fall back across multiple mirror sources for cloudflared download

### DIFF
--- a/app/src/main/java/com/soreverse/mcp/SettingsTunnelPage.kt
+++ b/app/src/main/java/com/soreverse/mcp/SettingsTunnelPage.kt
@@ -55,7 +55,6 @@ internal fun SettingsTunnelPage(t: UiText, settings: SettingsStore) {
     var tunnelLogLevel by remember { mutableStateOf(settings.tunnelLogLevel) }
     var tunnelReconnect by remember { mutableStateOf(settings.tunnelReconnect) }
     var tunnelKeepAlive by remember { mutableStateOf(settings.tunnelKeepAlive) }
-    var tunnelUseMirror by remember { mutableStateOf(settings.tunnelUseMirror) }
     var keepaliveInterval by remember {
         mutableStateOf(settings.tunnelKeepaliveIntervalSec.toString())
     }
@@ -138,13 +137,13 @@ internal fun SettingsTunnelPage(t: UiText, settings: SettingsStore) {
                                 withContext(Dispatchers.IO) {
                                     val tunnel = activeTunnel(context)
                                     if (tunnel != null) {
-                                        tunnel.downloadBinary(settings.tunnelUseMirror)
+                                        tunnel.downloadBinary()
                                     } else {
                                         // MCP server not running: use a throw-away
                                         // manager so the binary can still be
                                         // downloaded from this page.
                                         CloudflareTunnelManager(context, settings)
-                                            .downloadBinary(settings.tunnelUseMirror)
+                                            .downloadBinary()
                                     }
                                 }
                             }.onSuccess {
@@ -356,10 +355,6 @@ internal fun SettingsTunnelPage(t: UiText, settings: SettingsStore) {
                     it
             }
             GroupDivider()
-            ToggleRow(if (t.zh) "使用镜像源下载" else "Use mirror for download", tunnelUseMirror) {
-                tunnelUseMirror = it
-                settings.tunnelUseMirror = it
-            }
         }
         GlassGroup {
             ToggleRow(if (t.zh) "随服务自动启动" else "Auto-start with service", tunnelAutoStart) {

--- a/app/src/main/java/com/soreverse/mcp/core/CloudflareTunnelManager.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/CloudflareTunnelManager.kt
@@ -179,33 +179,27 @@ class CloudflareTunnelManager(private val context: Context, private val settings
     }
 
     /**
-     * Download the cloudflared binary from GitHub releases (or mirror if
-     * [useMirror] is true) to the app's private data directory.
+     * Download the cloudflared binary to the app's private data directory,
+     * automatically switching between GitHub official and multiple mirror
+     * sources until one succeeds.
      * Runs on the calling thread — caller should dispatch to [Dispatchers.IO].
      *
      * @throws Exception on download / write failure.
      */
-    fun downloadBinary(useMirror: Boolean = false) {
+    fun downloadBinary() {
         _binaryState.set(BinaryState.DOWNLOADING)
         try {
             val dir = File(context.filesDir, CLOUDFLARED_DIR)
             dir.mkdirs()
             val tmp = File(dir, "${CLOUDFLARED_FILE}.download")
-            // Build an ordered candidate list from the shared mirror policy:
-            // GitHub official first, then a pool of public GitHub mirrors as
-            // automatic fallbacks. If a single mirror (e.g. ghproxy) is
-            // unreachable we simply move on to the next candidate, so one down
-            // mirror can never block the binary download.
+            // Build an ordered candidate list: GitHub official first, then a
+            // pool of public GitHub mirrors as automatic fallbacks. Sources are
+            // switched automatically — if one (e.g. ghproxy) is unreachable we
+            // simply move on to the next candidate, so a single down source can
+            // never block the binary download.
             val policyCandidates = DownloadMirrorPolicy.candidates(CLOUDFLARED_DOWNLOAD_URL)
-            val urls = if (useMirror) {
-                // User asked for mirrors: try the mirror pool first, GitHub
-                // official remains the final fallback when every mirror fails.
-                policyCandidates
-            } else {
-                // GitHub official first; mirrors below are automatic fallbacks.
-                listOf(CLOUDFLARED_DOWNLOAD_URL) +
-                    policyCandidates.filter { it != CLOUDFLARED_DOWNLOAD_URL }
-            }
+            val urls = listOf(CLOUDFLARED_DOWNLOAD_URL) +
+                policyCandidates.filter { it != CLOUDFLARED_DOWNLOAD_URL }
             var lastError: Exception? = null
             for (url in urls) {
                 try {

--- a/app/src/main/java/com/soreverse/mcp/core/CloudflareTunnelManager.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/CloudflareTunnelManager.kt
@@ -1,3 +1,22 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Copyright (C) 2026 bilieebiliee1-design
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.soreverse.mcp.core
 
 import android.content.Context
@@ -26,8 +45,6 @@ class CloudflareTunnelManager(private val context: Context, private val settings
         /** GitHub release URL for the cloudflared Android arm64 binary. */
         const val CLOUDFLARED_DOWNLOAD_URL =
             "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-android-arm64"
-        const val CLOUDFLARED_MIRROR_URL =
-            "https://mirror.ghproxy.com/https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-android-arm64"
         const val CLOUDFLARED_DIR = "cloudflared"
         const val CLOUDFLARED_FILE = "cloudflared"
 
@@ -174,11 +191,20 @@ class CloudflareTunnelManager(private val context: Context, private val settings
             val dir = File(context.filesDir, CLOUDFLARED_DIR)
             dir.mkdirs()
             val tmp = File(dir, "${CLOUDFLARED_FILE}.download")
-            // Try URLs in order: selected source first, then fallback
+            // Build an ordered candidate list from the shared mirror policy:
+            // GitHub official first, then a pool of public GitHub mirrors as
+            // automatic fallbacks. If a single mirror (e.g. ghproxy) is
+            // unreachable we simply move on to the next candidate, so one down
+            // mirror can never block the binary download.
+            val policyCandidates = DownloadMirrorPolicy.candidates(CLOUDFLARED_DOWNLOAD_URL)
             val urls = if (useMirror) {
-                listOf(CLOUDFLARED_MIRROR_URL, CLOUDFLARED_DOWNLOAD_URL)
+                // User asked for mirrors: try the mirror pool first, GitHub
+                // official remains the final fallback when every mirror fails.
+                policyCandidates
             } else {
-                listOf(CLOUDFLARED_DOWNLOAD_URL, CLOUDFLARED_MIRROR_URL)
+                // GitHub official first; mirrors below are automatic fallbacks.
+                listOf(CLOUDFLARED_DOWNLOAD_URL) +
+                    policyCandidates.filter { it != CLOUDFLARED_DOWNLOAD_URL }
             }
             var lastError: Exception? = null
             for (url in urls) {

--- a/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
@@ -530,10 +530,6 @@ class SettingsStore(context: Context) {
             }
         ).apply()
 
-    var tunnelUseMirror: Boolean
-        get() = prefs.getBoolean("tunnelUseMirror", false)
-        set(value) = prefs.edit().putBoolean("tunnelUseMirror", value).apply()
-
     var tunnelReconnect: Boolean
         get() = prefs.getBoolean("tunnelReconnect", true)
         set(value) = prefs.edit().putBoolean("tunnelReconnect", value).apply()


### PR DESCRIPTION
## 问题

cloudflared（CF 隧道）二进制下载原先需手动选择「使用镜像源下载」，且默认仅支持 GitHub 官方 + 单个镜像（mirror.ghproxy.com）。当被选中的源无法连接时，下载即失败，导致 CF 隧道无法启用。

## 改动

- **合并镜像下载到 CF 下载本身**：移除设置页「使用镜像源下载」开关（及 `tunnelUseMirror` 偏好项）。
- **自动切换下载源**：`downloadBinary()` 不再接收 `useMirror` 参数，下载时自动按序尝试 GitHub 官方 + `DownloadMirrorPolicy` 的多镜像源池，任一个源失败即顺次回退，直至成功，单个源故障不再阻塞。
- 删除已不再引用的 `CLOUDFLARED_MIRROR_URL` 常量。
- 为被修改的源码文件补充 AGPL-3.0 许可证头。

## 涉及文件

- `app/src/main/java/com/soreverse/mcp/core/CloudflareTunnelManager.kt`
- `app/src/main/java/com/soreverse/mcp/SettingsTunnelPage.kt`
- `app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt`

## 验证说明

改动逻辑复用已测试的 `DownloadMirrorPolicy`；本地沙箱无 Android SDK，无法本地编译，建议合入后由 CI/本地跑一次相关构建验证。