### PR TITLE
fix(blutter-matrix): point ICU host-tool checks at the build tree bin

### DIFF
--- a/tools/blutter-matrix/build_icu_android.sh
+++ b/tools/blutter-matrix/build_icu_android.sh
@@ -1,4 +1,21 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Copyright (C) 2026 bilieebiliee1-design
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
 set -euo pipefail
 
 root="$1"
@@ -35,7 +52,7 @@ fi
 rm -rf "$target" "$install"
 mkdir -p "$host" "$target" "$install"
 
-if [ ! -x "$host/install/bin/genccode" ] || [ ! -x "$host/install/bin/pkgdata" ]; then
+if [ ! -x "$host/bin/genccode" ] || [ ! -x "$host/bin/pkgdata" ]; then
   rm -rf "$host"
   mkdir -p "$host"
   cd "$host"
@@ -56,8 +73,8 @@ if [ ! -x "$host/install/bin/genccode" ] || [ ! -x "$host/install/bin/pkgdata" ]
   make -j"$jobs"
   make install
 fi
-test -x "$host/install/bin/genccode"
-test -x "$host/install/bin/pkgdata"
+test -x "$host/bin/genccode"
+test -x "$host/bin/pkgdata"
 
 cd "$target"
 "$src/configure" \


### PR DESCRIPTION
基于 main 新建，仅 cherry-pick 提交 7b29d58 的修复：ICU host-tool 检查由 `$host/install/bin` 指向 `$host/bin`（build tree bin）。补充 AGPL-3.0 许可证头。