### PR TITLE
feat(core): stop analysis when memory is insufficient

### DIFF
--- a/app/src/main/java/com/soreverse/mcp/core/MemoryGuard.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/MemoryGuard.kt
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2026 bilieebiliee1-design
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+package com.soreverse.mcp.core
+
+/**
+ * Thrown when an analysis cannot start because the process heap does not have
+ * enough headroom to safely hold the input file and its parse copies. Mapped by
+ * [com.soreverse.mcp.engine.EngineRuntime.guarded] to the `INSUFFICIENT_MEMORY`
+ * MCP error so callers see a clear message instead of an `OutOfMemoryError`.
+ */
+class InsufficientMemoryException(message: String) : IllegalStateException(message)
+
+/**
+ * Heap-aware gate that stops a memory-hungry analysis before it begins when the
+ * process cannot safely accommodate the target file. SOMCP loads a whole ELF/APK
+ * into a `ByteArray` and then keeps several parse copies (LIEF native parse,
+ * xanso section recovery, rizin buffers), so a large library on a constrained
+ * device can otherwise crash the app with an `OutOfMemoryError`.
+ *
+ * Used at the entry points that read a full file into memory:
+ *  - [com.soreverse.mcp.engine.EngineRuntime.openWorkspace] (so_open / UI open /
+ *    AI deep-analysis tools),
+ *  - [com.soreverse.mcp.engine.EngineRuntime.analyzeApk] (apk_analyze),
+ *  - the scan-time metadata fallback that parses a whole SO,
+ *  - the Flutter (Blutter) inspect/analyze paths.
+ */
+object MemoryGuard {
+
+    /** Transient copies a full ELF/APK parse typically needs (input + LIEF + rizin/recovery). */
+    const val DEFAULT_MULTIPLICITY = 3
+
+    /** Extra headroom (MiB) kept free so the app stays responsive after the parse. */
+    const val DEFAULT_RESERVE_MIB = 48L
+
+    /** Absolute floor (MiB): refuse when less than this much heap is left at all. */
+    const val MIN_HEADROOM_MIB = 16L
+
+    private const val MIB = 1024L * 1024L
+
+    /** Heap (MiB) the process can still allocate before an OutOfMemoryError. */
+    fun heapHeadroomMiB(): Long {
+        val runtime = Runtime.getRuntime()
+        val headroom = runtime.maxMemory() - (runtime.totalMemory() - runtime.freeMemory())
+        return (headroom.coerceAtLeast(0L)) / MIB
+    }
+
+    /**
+     * Refuse to start an analysis that needs to hold [requiredBytes] of input in
+     * memory. [what] names the operation for the error message. Throws
+     * [InsufficientMemoryException] when the estimated requirement (input times
+     * [DEFAULT_MULTIPLICITY] plus [DEFAULT_RESERVE_MIB]) exceeds the available heap
+     * headroom, or when the process is already below [MIN_HEADROOM_MIB].
+     */
+    fun ensureAnalysisMemory(requiredBytes: Long, what: String) {
+        val requirementMiB = (requiredBytes.coerceAtLeast(0L) * DEFAULT_MULTIPLICITY) / MIB
+        val headroomMiB = heapHeadroomMiB()
+        if (headroomMiB < MIN_HEADROOM_MIB || headroomMiB < requirementMiB + DEFAULT_RESERVE_MIB) {
+            val runtime = Runtime.getRuntime()
+            val maxMiB = runtime.maxMemory() / MIB
+            val usedMiB = (runtime.totalMemory() - runtime.freeMemory()) / MIB
+            throw InsufficientMemoryException(
+                "$what needs about $requirementMiB MiB of heap headroom, but only ~$headroomMiB MiB is " +
+                    "available (heap max ~$maxMiB MiB, used ~$usedMiB MiB). Close other opened SO workspaces " +
+                    "or stop emulation, then retry — or analyze a smaller file."
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/soreverse/mcp/engine/BlutterCoordinator.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/BlutterCoordinator.kt
@@ -1,6 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2026 bilieebiliee1-design
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
 package com.soreverse.mcp.engine
 
 import android.content.Context
+import com.soreverse.mcp.core.InsufficientMemoryException
+import com.soreverse.mcp.core.MemoryGuard
 import com.soreverse.mcp.core.err
 import com.soreverse.mcp.core.ok
 import com.soreverse.mcp.core.str
@@ -59,6 +78,10 @@ internal class BlutterCoordinator(
             if (file.isDirectory) {
                 inspectDirectory(file, path, args.str("abi", "auto"))
             } else if (file.isFile) {
+                MemoryGuard.ensureAnalysisMemory(
+                    file.length(),
+                    "Inspecting Flutter APK ${file.name}"
+                )
                 val bytes = file.readBytes()
                 if (!file.extension.equals(
                         "apk",
@@ -91,6 +114,10 @@ internal class BlutterCoordinator(
                     ok(inventory.put("selectedAnalysis", detailed))
                 }
             } else if (workDirectory != null) {
+                MemoryGuard.ensureAnalysisMemory(
+                    workDirectory.fileSize(path) ?: ApkAnalyzer.MAX_INPUT_BYTES,
+                    "Inspecting Flutter APK $path"
+                )
                 val bytes = workDirectory.readFile(path, ApkAnalyzer.MAX_INPUT_BYTES)
                 val inventory = FlutterArtifactInspector.inspectApk(
                     bytes,
@@ -124,6 +151,13 @@ internal class BlutterCoordinator(
                     path
                 )
             }
+        } catch (error: InsufficientMemoryException) {
+            err(
+                "INSUFFICIENT_MEMORY",
+                error.message ?: "Insufficient memory to inspect Flutter artifacts",
+                "path",
+                path
+            )
         } catch (error: Exception) {
             err(
                 error.message?.substringBefore(':')?.takeIf {
@@ -145,10 +179,22 @@ internal class BlutterCoordinator(
             libs to FlutterArtifactInspector.inspectLibraries(libs)
         }
         if (resolved.isFailure) {
-            val problem = JSONObject().put("code", "INPUT_RESOLUTION_FAILED").put(
-                "message",
-                resolved.exceptionOrNull()?.message ?: "Cannot resolve Flutter libraries"
-            ).put("recoverable", false).put("stage", "resolving_input")
+            val failure = resolved.exceptionOrNull()
+            val problem = JSONObject()
+                .put(
+                    "code",
+                    if (failure is InsufficientMemoryException) {
+                        "INSUFFICIENT_MEMORY"
+                    } else {
+                        "INPUT_RESOLUTION_FAILED"
+                    }
+                )
+                .put(
+                    "message",
+                    failure?.message ?: "Cannot resolve Flutter libraries"
+                )
+                .put("recoverable", false)
+                .put("stage", "resolving_input")
             store.update(jobId, "failed", "resolving_input", problem)
             return ok(JSONObject().put("jobId", jobId).put("status", "failed").put("error", problem))
         }
@@ -290,6 +336,10 @@ internal class BlutterCoordinator(
                 file.resolve("libflutter.so").takeIf { it.isFile }
                     ?: file.resolve("Flutter").takeIf { it.isFile }
                     ?: error("FLUTTER_LIBS_NOT_FOUND")
+            MemoryGuard.ensureAnalysisMemory(
+                app.length() + flutter.length(),
+                "Analyzing Flutter libraries in ${file.name}"
+            )
             return FlutterLibraries(
                 file.name,
                 "arm64-v8a",
@@ -300,10 +350,18 @@ internal class BlutterCoordinator(
             )
         }
         val bytes = if (file.isFile) {
+            MemoryGuard.ensureAnalysisMemory(
+                file.length(),
+                "Analyzing Flutter APK ${file.name}"
+            )
             file.readBytes()
         } else {
-            workDirectory?.readFile(path, ApkAnalyzer.MAX_INPUT_BYTES)
-                ?: error("INPUT_NOT_FOUND")
+            val dir = workDirectory ?: error("INPUT_NOT_FOUND")
+            MemoryGuard.ensureAnalysisMemory(
+                dir.fileSize(path) ?: ApkAnalyzer.MAX_INPUT_BYTES,
+                "Analyzing Flutter APK $path"
+            )
+            dir.readFile(path, ApkAnalyzer.MAX_INPUT_BYTES)
         }
         return FlutterArtifactInspector.extractLibraries(bytes, path, args.str("abi", "arm64-v8a"))
     }
@@ -325,6 +383,10 @@ internal class BlutterCoordinator(
             )
         }
         val abi = if (requestedAbi == "auto") "arm64-v8a" else requestedAbi
+        MemoryGuard.ensureAnalysisMemory(
+            app.length() + flutter.length(),
+            "Inspecting Flutter libraries in ${dir.name}"
+        )
         return ok(
             FlutterArtifactInspector.inspectLibraries(
                 FlutterLibraries(

--- a/app/src/main/java/com/soreverse/mcp/engine/EngineRuntime.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/EngineRuntime.kt
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
+// Copyright (C) 2026 bilieebiliee1-design
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -10,11 +12,15 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Affero General Public License for more details.
 //
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
 package com.soreverse.mcp.engine
 
 import android.content.Context
 import android.net.Uri
 import com.soreverse.mcp.core.AppLog
+import com.soreverse.mcp.core.InsufficientMemoryException
 import com.soreverse.mcp.core.err
 import java.security.MessageDigest
 import java.util.concurrent.CancellationException
@@ -107,6 +113,11 @@ internal class EngineRuntime(internal val context: Context) {
                 "Invalid URI",
                 ignoreCase = true
             ) -> err("INVALID_WORK_DIRECTORY", message)
+
+            error is InsufficientMemoryException -> err(
+                "INSUFFICIENT_MEMORY",
+                message
+            )
 
             error is java.io.IOException -> err(
                 "IO_ERROR",

--- a/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeSources.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/EngineRuntimeSources.kt
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
+// Copyright (C) 2026 bilieebiliee1-design
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -10,11 +12,16 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Affero General Public License for more details.
 //
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
 package com.soreverse.mcp.engine
 
 import android.net.Uri
 import com.soreverse.mcp.BuildConfig
 import com.soreverse.mcp.core.AppLog
+import com.soreverse.mcp.core.InsufficientMemoryException
+import com.soreverse.mcp.core.MemoryGuard
 import com.soreverse.mcp.core.SelfArtifactGuard
 import com.soreverse.mcp.core.SettingsStore
 import com.soreverse.mcp.core.err
@@ -243,9 +250,13 @@ internal fun EngineRuntime.analyzeApk(path: String, entryLimit: Int = 500): JSON
     }
     val bytes = try {
         if (local.isFile) {
+            MemoryGuard.ensureAnalysisMemory(
+                local.length(),
+                "Analyzing APK ${local.name}"
+            )
             local.readBytes()
         } else {
-            (
+            val workDirForApk =
                 workDir
                     ?: return@guarded err(
                         "WORK_DIRECTORY_NOT_SELECTED",
@@ -253,7 +264,11 @@ internal fun EngineRuntime.analyzeApk(path: String, entryLimit: Int = 500): JSON
                         "path",
                         path
                     )
-                ).readFile(path, ApkAnalyzer.MAX_INPUT_BYTES)
+            MemoryGuard.ensureAnalysisMemory(
+                workDirForApk.fileSize(path) ?: ApkAnalyzer.MAX_INPUT_BYTES,
+                "Analyzing APK $path"
+            )
+            workDirForApk.readFile(path, ApkAnalyzer.MAX_INPUT_BYTES)
         }
     } catch (error: ApkAnalysisLimitException) {
         return@guarded err(
@@ -590,6 +605,13 @@ internal fun EngineRuntime.openWorkspace(path: String, temporary: Boolean): Work
     }
     val key = sourceKey(src).ifBlank { keyFallback }
     workspaceBySourceKey[key]?.let { existingId -> workspaces[existingId]?.let { return it } }
+    // Stop before reading the whole SO into memory when the process heap cannot
+    // safely hold it plus the parse copies — otherwise a large libapp.so on a
+    // constrained device ends in an OutOfMemoryError instead of a clean error.
+    MemoryGuard.ensureAnalysisMemory(
+        src.size,
+        "Opening ${src.name} for analysis"
+    )
     val original = when (src.source) {
         "build_output", "local_file" -> runCatching {
             File(src.path).readBytes()
@@ -933,8 +955,14 @@ internal fun EngineRuntime.sourceSummary(dir: WorkDirectory, src: SoSource): Sou
             }
         }
 
-        // Fallback: read full file and parse with LIEF
+        // Fallback: read full file and parse with LIEF. When the heap cannot hold
+        // the file, degrade to an "unknown" summary instead of crashing the scan
+        // with an OutOfMemoryError.
         runCatching {
+            MemoryGuard.ensureAnalysisMemory(
+                src.size,
+                "Reading ${src.name} metadata during scan"
+            )
             lief.parse(dir.readSource(src)).let { elf ->
                 SourceSummary(
                     elf.architecture,
@@ -956,6 +984,10 @@ internal fun EngineRuntime.sourceSummary(dir: WorkDirectory, src: SoSource): Sou
                         )
                     )
                 }
+            }
+        }.onFailure { failure ->
+            if (failure is InsufficientMemoryException) {
+                AppLog.w(failure.message ?: "Skipping metadata parse: insufficient memory")
             }
         }.getOrElse { SourceSummary("unknown", 0, "little", false, true) }
     }

--- a/app/src/main/java/com/soreverse/mcp/engine/Storage.kt
+++ b/app/src/main/java/com/soreverse/mcp/engine/Storage.kt
@@ -1,3 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2026 bilieebiliee1-design
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
 package com.soreverse.mcp.engine
 
 import android.content.ContentResolver
@@ -410,6 +427,24 @@ class WorkDirectory(private val context: Context, private val treeUri: Uri) {
             found ?: error("File not found in work directory: $relativePath"),
             maxBytes
         )
+    }
+
+    /**
+     * Size in bytes of a file inside the work directory, or null when it cannot be
+     * found or measured. Used by the memory guard to estimate how much heap an
+     * analysis of [relativePath] would need before reading it fully into memory.
+     */
+    fun fileSize(relativePath: String): Long? {
+        var result: Long? = null
+        walk(
+            treeUri,
+            "",
+            0,
+            ScanOptions(scanApks = true, scanSubdirectories = true, maxDepth = 32)
+        ) { _, _, path, size, _ ->
+            if (path == relativePath) result = size
+        }
+        return result
     }
 
     fun writeRootFile(displayName: String, bytes: ByteArray, mimeType: String = "application/octet-stream"): SoSource {


### PR DESCRIPTION
## 概述

为 SOMCP 增加内存守卫：当进程堆不足以安全容纳目标文件及其解析副本时，**停止分析**并返回明确的 `INSUFFICIENT_MEMORY` MCP 错误，而不是崩溃为 `OutOfMemoryError`。

## 改动

- **新增** `core/MemoryGuard.kt`：
  - `MemoryGuard.ensureAnalysisMemory(requiredBytes, what)` 按「文件大小 × 3（输入 + LIEF + rizin/recovery 副本）+ 48 MiB 预留」估算需求，与运行时堆余量对比，不足即抛 `InsufficientMemoryException`（含估算需求、堆余量、堆上限/已用提示），并设 16 MiB 绝对下限。
- **接入点**：
  - `engine/EngineRuntimeSources.kt`：`openWorkspace`（so_open / UI 打开 / AI 分析入口）、`analyzeApk`（本地 + 工作目录 APK）、`sourceSummary` 扫描期元数据回退（内存不足降级为 `unknown` 摘要并记日志，不中断目录扫描）。
  - `engine/BlutterCoordinator.kt`：Flutter APK 检查/分析、libapp+libflutter 库分析路径均加守卫并捕获，返回 `INSUFFICIENT_MEMORY`。
  - `engine/EngineRuntime.kt`：`guarded` 统一将 `InsufficientMemoryException` 映射为错误码 `INSUFFICIENT_MEMORY`。
  - `engine/Storage.kt`：新增 `WorkDirectory.fileSize()`，读取大小无需整文件载入内存。
- 所有新增/修改源码文件均已添加 AGPL-3.0 许可证头（`Copyright (C) 2026 bilieebiliee1-design`）。

## 校验

- `MemoryGuard.kt` 通过 Kotlin 2.0.21 编译器前端解析/类型检查（零错误）。
- 全部改动文件通过分隔符配平检查。
- 沙箱无 Android SDK，未执行完整 APK 构建，建议 CI/本地跑 `:app:compileDebugKotlin` 最终确认。