### PR TITLE
fix(workflow): don't abort issue auto-reply when no attachments are present

### DIFF
--- a/.github/workflows/issues-auto-reply.yml
+++ b/.github/workflows/issues-auto-reply.yml
@@ -151,10 +151,14 @@ jobs:
           ATTACH_LIMIT=200000
           ATTACH_TOTAL=0
           idx=0
-          # 提取 GitHub 用户上传附件的链接并去重
-          printf '%s' "$CONTENT" \
+          # 提取 GitHub 用户上传附件的链接并去重。
+          # grep 无匹配时返回码为 1，而 set -o pipefail 会把非零状态沿管道透传到
+          # set -e，导致"无附件"的 issue 在此步提前退出，后续 LLM 回复全部被跳过。
+          # 用命令替换 + `|| true` 屏蔽该状态，保证无附件时也能正常走到结尾。
+          LINKS=$(printf '%s' "$CONTENT" \
             | grep -oiE 'https://github\.com/user-attachments/files/[0-9]+/[^)[:space:]]+' \
-            | tr -d '\r' | sort -u \
+            | tr -d '\r' | sort -u || true)
+          printf '%s\n' "$LINKS" \
             | while IFS= read -r url; do
                 [ -n "$url" ] || continue
                 idx=$((idx+1))


### PR DESCRIPTION
## 问题

`LLM Auto-Reply Issues` 工作流在运行 [32914773394](https://github.com/bilieebiliee1-design/SOMCP/actions/runs/32914773394) 时失败。

**失败步骤**：`Download and extract issue attachments`（exit code 1）

**根因**：触发该次运行的是 issue #57（正文无任何 `user-attachments` 附件）。该步骤在 `set -euo pipefail` 下执行：

```bash
printf '%s' "$CONTENT" \
  | grep -oiE 'https://github\.com/user-attachments/...' \
  | tr -d '\r' | sort -u \
  | while IFS= read -r url; do ... done
```

当 issue 正文没有附件链接时，`grep` 返回码为 1（无匹配），`pipefail` 会把该非零状态沿管道透传，`set -e` 随即终止整个步骤。于是 **任何不携带附件的 issue 都会让"生成 LLM 回复"和"发布评论"两个步骤被跳过**。

## 修复

用命令替换 + `|| true` 屏蔽 grep 无匹配的退出码，再把收集到的链接逐行喂给读取循环：

```bash
LINKS=$(printf '%s' "$CONTENT" \
  | grep -oiE '...' \
  | tr -d '\r' | sort -u || true)
printf '%s\n' "$LINKS" \
  | while IFS= read -r url; do ... done
```

- 无附件：`LINKS` 为空，循环自然结束，步骤正常完成。
- 有附件：逻辑与之前完全一致，逐个下载并读取。

已在本地用 `set -euo pipefail` 验证两种分支（有/无附件）均正常退出。

## 验证

- 无附件输入 → 步骤 exit 0，`attachments_found=false`。
- 含附件输入 → 两个链接均被正常提取。