### PR TITLE
feat(blutter): 增加 Dart 3.13.0 / 3.13.1 支持，扩展 Flutter 3.47.x 版本

### DIFF
--- a/tools/blutter-matrix/curated-versions.json
+++ b/tools/blutter-matrix/curated-versions.json
@@ -1,7 +1,9 @@
 {
   "dartVersions": [
     "3.11.5",
-    "3.12.2"
+    "3.12.2",
+    "3.13.0",
+    "3.13.1"
   ],
   "compressedPointers": true,
   "analysis": true


### PR DESCRIPTION
## 变更内容

issue #5 扩展 Flutter 版本支持，将 **Dart 3.13.0** 与 **Dart 3.13.1** 加入 curated 构建矩阵（`tools/blutter-matrix/curated-versions.json`）。

curated Dart 版本由 3.11.5 / 3.12.2 扩展为 3.11.5 / 3.12.2 / 3.13.0 / 3.13.1，使 blutter-matrix 管线在 NDK 交叉编译出真实 Runner 后可被 curate 并纳入 manifest。

### 版本映射（数据源：Flutter 官方 releases 存档，与管线同源）

| Flutter 版本 | Dart 版本 | 状态 |
| --- | --- | --- |
| 3.47.0 | 3.13.0 | 本次新增 curated |
| 3.47.1 | 3.13.1 | 本次新增 curated |
| 3.44.8 / 3.44.9 | 3.12.2 | 已 curated，自动覆盖 |

### 说明

- 变更仅涉及 `tools/blutter-matrix/curated-versions.json` 一个文件（纯配置，不涉及许可证头）。
- Runner 的实际 交叉编译 / smoke / manifest 更新由 CI（test-v7.yml / release.yml 中的 best-effort 步骤）在实跑时完成，本 PR 不手工伪造 manifest 或二进制。
- `3.47.0-0.2~0.4.pre` / `3.48.0-0.1~0.2.pre` 属于 **beta channel** 发行版，矩阵 `channels` 仅含 `stable`，故不在本次支持范围内（如需支持需另行扩展 channel 配置）。

## 测试

- 已本地校验 `curated-versions.json` 为合法 JSON。
- 参考既有 PR #47（Dart 3.11.5 入 curated 矩阵）模式，改动保持一致。