### PR TITLE
Redesign update interface and add beta (Pre-release) channel

### DIFF
--- a/app/src/main/java/com/soreverse/mcp/SettingsUpdatesPage.kt
+++ b/app/src/main/java/com/soreverse/mcp/SettingsUpdatesPage.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.unit.dp
 import com.soreverse.mcp.core.GitHubRelease
 import com.soreverse.mcp.core.GitHubUpdateManager
 import com.soreverse.mcp.core.SettingsStore
+import com.soreverse.mcp.core.UpdateChannel
 import com.soreverse.mcp.core.UpdateCheckResult
 import com.soreverse.mcp.core.UpdateDownloadEvent
 import java.io.File
@@ -111,13 +112,14 @@ internal fun SettingsUpdatesPage(
         }
     }
 
-    fun checkUpdates() {
+    fun checkUpdates(target: String = channel) {
         if (checking) return
         checking = true
         error = ""
         status = if (t.zh) "正在检查 GitHub Releases…" else "Checking GitHub Releases…"
+        val updateChannel = if (target == "beta") UpdateChannel.BETA else UpdateChannel.STABLE
         scope.launch {
-            manager.check()
+            manager.check(updateChannel)
                 .onSuccess { result ->
                     when (result) {
                         is UpdateCheckResult.Available -> {
@@ -131,7 +133,7 @@ internal fun SettingsUpdatesPage(
                             release = null
                             onRelease(null)
                             status =
-                                if (t.zh) "当前已是最新正式发行版" else "You are using the latest stable release"
+                                if (t.zh) "当前已是最新${if (updateChannel == UpdateChannel.BETA) "测试版" else "正式发行版"}" else if (updateChannel == UpdateChannel.BETA) "You are on the latest beta build" else "You are using the latest stable release"
                         }
                     }
                 }
@@ -224,19 +226,23 @@ internal fun SettingsUpdatesPage(
     }
     val headline = when {
         checking -> if (t.zh) "正在检查更新…" else "Checking for updates…"
-        available -> if (t.zh) "发现新版本" else "New update available"
-        isBeta -> if (t.zh) "测试版通道" else "Beta channel"
+        available -> if (isBeta) (if (t.zh) "发现新测试版" else "New beta available") else (if (t.zh) "发现新版本" else "New update available")
+        isBeta -> if (t.zh) "已是最新测试版" else "You're on the latest beta"
         else -> if (t.zh) "已是最新版本" else "You're up to date"
     }
     val subtitle = when {
         checking -> if (t.zh) "正在查询 GitHub Releases…" else "Querying GitHub Releases…"
         available -> release?.name?.ifBlank {
-            if (t.zh) "体验最新的实验性功能与架构优化" else "Experience the latest experimental features"
+            if (isBeta) {
+                if (t.zh) "体验最新的实验性测试构建" else "Experience the latest experimental beta build"
+            } else {
+                if (t.zh) "体验最新的实验性功能与架构优化" else "Experience the latest experimental features"
+            }
         } ?: ""
         isBeta -> if (t.zh) {
-            "测试版通道暂未开放，请切换到正式版通道检查发行版。"
+            "您正在使用最新测试版构建，无需进行更新操作。"
         } else {
-            "The beta channel is not available yet; switch to the stable channel."
+            "You are on the latest beta build; no update is needed."
         }
         else -> if (t.zh) {
             "您的 SOMCP 客户端当前已更新至最新稳定版，无需进行更新操作。"
@@ -256,7 +262,18 @@ internal fun SettingsUpdatesPage(
         // Channel pill (正式版 / 测试版)
         ChannelSegmentsPill(
             selected = channel,
-            onSelect = { channel = it },
+            onSelect = { newChannel ->
+                if (newChannel == channel) return@ChannelSegmentsPill
+                downloadJob?.cancel()
+                downloadJob = null
+                downloading = false
+                downloadPhase = ""
+                verifyNote = ""
+                downloadedFile = null
+                status = ""
+                channel = newChannel
+                checkUpdates(newChannel)
+            },
             zh = t.zh
         )
         // Hero: glowing app icon + dynamic state headline

--- a/app/src/main/java/com/soreverse/mcp/SettingsUpdatesPage.kt
+++ b/app/src/main/java/com/soreverse/mcp/SettingsUpdatesPage.kt
@@ -132,8 +132,11 @@ internal fun SettingsUpdatesPage(
                         UpdateCheckResult.Current -> {
                             release = null
                             onRelease(null)
-                            status =
-                                if (t.zh) "当前已是最新${if (updateChannel == UpdateChannel.BETA) "测试版" else "正式发行版"}" else if (updateChannel == UpdateChannel.BETA) "You are on the latest beta build" else "You are using the latest stable release"
+                            status = if (updateChannel == UpdateChannel.BETA) {
+                                if (t.zh) "当前已是最新测试版" else "You are on the latest beta build"
+                            } else {
+                                if (t.zh) "当前已是最新正式发行版" else "You are using the latest stable release"
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/soreverse/mcp/SettingsUpdatesPage.kt
+++ b/app/src/main/java/com/soreverse/mcp/SettingsUpdatesPage.kt
@@ -1,11 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2026 bilieebiliee1-design
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
 package com.soreverse.mcp
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.RocketLaunch
+import androidx.compose.material.icons.filled.Science
+import androidx.compose.material.icons.filled.Terminal
+import androidx.compose.material.icons.filled.Verified
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -16,7 +49,16 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.soreverse.mcp.core.GitHubRelease
 import com.soreverse.mcp.core.GitHubUpdateManager
@@ -54,6 +96,7 @@ internal fun SettingsUpdatesPage(
     var verifyNote by remember { mutableStateOf("") }
     var status by remember { mutableStateOf("") }
     var error by remember { mutableStateOf("") }
+    var channel by remember { mutableStateOf("stable") }
 
     LaunchedEffect(release?.tag) {
         downloadedFile = release?.let(manager::cachedDownload)
@@ -171,7 +214,66 @@ internal fun SettingsUpdatesPage(
         }
     }
 
+    val isBeta = channel == "beta"
+    val accent = MaterialTheme.colorScheme.primary
+    val available = release != null
+    val heroIcon: ImageVector = when {
+        isBeta -> Icons.Default.Science
+        available -> Icons.Default.RocketLaunch
+        else -> Icons.Default.Verified
+    }
+    val headline = when {
+        checking -> if (t.zh) "正在检查更新…" else "Checking for updates…"
+        available -> if (t.zh) "发现新版本" else "New update available"
+        isBeta -> if (t.zh) "测试版通道" else "Beta channel"
+        else -> if (t.zh) "已是最新版本" else "You're up to date"
+    }
+    val subtitle = when {
+        checking -> if (t.zh) "正在查询 GitHub Releases…" else "Querying GitHub Releases…"
+        available -> release?.name?.ifBlank {
+            if (t.zh) "体验最新的实验性功能与架构优化" else "Experience the latest experimental features"
+        } ?: ""
+        isBeta -> if (t.zh) {
+            "测试版通道暂未开放，请切换到正式版通道检查发行版。"
+        } else {
+            "The beta channel is not available yet; switch to the stable channel."
+        }
+        else -> if (t.zh) {
+            "您的 SOMCP 客户端当前已更新至最新稳定版，无需进行更新操作。"
+        } else {
+            "Your SOMCP client is already on the latest stable version."
+        }
+    }
+    val tagLower = release?.tag?.lowercase().orEmpty()
+    val versionBadge = when {
+        isBeta -> if (t.zh) "测试版" else "BETA"
+        listOf("beta", "alpha", "rc", "pre", "snapshot").any { it in tagLower } -> "BETA"
+        else -> null
+    }
+    val versionText = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+
     PageScroll {
+        // Channel pill (正式版 / 测试版)
+        ChannelSegmentsPill(
+            selected = channel,
+            onSelect = { channel = it },
+            zh = t.zh
+        )
+        // Hero: glowing app icon + dynamic state headline
+        UpdateHero(
+            icon = heroIcon,
+            headline = headline,
+            subtitle = subtitle,
+            tint = if (isBeta) MaterialTheme.colorScheme.tertiary else accent
+        )
+        // Current-version "power card"
+        UpdateVersionCard(
+            versionText = versionText,
+            badge = versionBadge,
+            accent = accent,
+            zh = t.zh
+        )
+        // Update source + auto-check controls
         GlassGroup {
             Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text(
@@ -188,10 +290,6 @@ internal fun SettingsUpdatesPage(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Text(
-                    "${if (t.zh) "当前版本" else "Current version"}: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
-                    style = MaterialTheme.typography.bodyMedium
-                )
             }
             GroupDivider()
             ToggleRow(if (t.zh) "启动时自动检查" else "Check automatically at startup", autoCheck) {
@@ -202,7 +300,7 @@ internal fun SettingsUpdatesPage(
             NavRow(
                 if (checking) (if (t.zh) "正在检查…" else "Checking…") else (if (t.zh) "立即检查更新" else "Check now"),
                 status,
-                Icons.Default.Info,
+                Icons.Default.Refresh,
                 onClick = ::checkUpdates
             )
         }
@@ -221,19 +319,48 @@ internal fun SettingsUpdatesPage(
             }
         }
         release?.let { update ->
-            GlassGroup {
+            GlassGroup(title = if (t.zh) "更新日志" else "Changelog") {
                 Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                    Text(
-                        update.name,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold
-                    )
-                    Text(
-                        update.tag,
-                        color = MaterialTheme.colorScheme.primary,
-                        style = MaterialTheme.typography.labelLarge
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        Text(
+                            update.name,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold
+                        )
+                        Spacer(Modifier.weight(1f))
+                        Box(
+                            Modifier
+                                .clip(RoundedCornerShape(999.dp))
+                                .background(accent.copy(alpha = 0.16f))
+                                .border(
+                                    BorderStroke(1.dp, accent.copy(alpha = 0.3f)),
+                                    RoundedCornerShape(999.dp)
+                                )
+                                .padding(horizontal = 9.dp, vertical = 3.dp)
+                        ) {
+                            Text(
+                                update.tag,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = accent,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
                     if (update.notes.isNotBlank()) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            IconSmall(Icons.Default.History, MaterialTheme.colorScheme.onSurfaceVariant)
+                            Text(
+                                if (t.zh) "更新内容" else "What's new",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                         MarkdownMessageContent(
                             update.notes,
                             selectable = true
@@ -285,6 +412,171 @@ internal fun SettingsUpdatesPage(
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun IconSmall(imageVector: ImageVector, tint: Color) {
+    androidx.compose.material3.Icon(
+        imageVector,
+        null,
+        tint = tint,
+        modifier = Modifier.size(16.dp)
+    )
+}
+
+@Composable
+private fun ChannelSegmentsPill(selected: String, onSelect: (String) -> Unit, zh: Boolean) {
+    val options = listOf(
+        "stable" to (if (zh) "正式版" else "Stable"),
+        "beta" to (if (zh) "测试版" else "Beta")
+    )
+    val shape = RoundedCornerShape(999.dp)
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.72f))
+            .border(BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.14f)), shape)
+            .padding(3.dp)
+    ) {
+        options.forEach { (key, label) ->
+            val active = selected == key
+            Text(
+                label,
+                Modifier
+                    .weight(1f)
+                    .clip(shape)
+                    .background(if (active) MaterialTheme.colorScheme.surfaceVariant else Color.Transparent)
+                    .clickable { onSelect(key) }
+                    .padding(vertical = 9.dp),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (active) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                fontWeight = if (active) FontWeight.SemiBold else FontWeight.Medium
+            )
+        }
+    }
+}
+
+@Composable
+private fun UpdateHero(icon: ImageVector, headline: String, subtitle: String, tint: Color) {
+    Column(
+        Modifier.fillMaxWidth().padding(top = 4.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.padding(bottom = 20.dp)
+        ) {
+            // Glowing halo
+            Box(
+                Modifier
+                    .size(104.dp)
+                    .background(tint.copy(alpha = 0.30f), CircleShape)
+                    .blur(30.dp)
+            )
+            // Icon tile
+            Box(
+                Modifier
+                    .size(84.dp)
+                    .clip(CircleShape)
+                    .background(Brush.verticalGradient(listOf(Color(0xFF1D2027), Color(0xFF14161C))))
+                    .border(BorderStroke(1.dp, tint.copy(alpha = 0.35f)), CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                androidx.compose.material3.Icon(
+                    icon,
+                    null,
+                    tint = tint,
+                    modifier = Modifier.size(42.dp)
+                )
+            }
+        }
+        Text(
+            headline,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(10.dp))
+        Text(
+            subtitle,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun UpdateVersionCard(versionText: String, badge: String?, accent: Color, zh: Boolean) {
+    val shape = RoundedCornerShape(26.dp)
+    val bg = Brush.verticalGradient(listOf(Color(0xFF1E2026), Color(0xFF15171D)))
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .background(bg)
+            .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.08f)), shape)
+            .padding(horizontal = 18.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Row(
+            Modifier.weight(1f),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Box(
+                Modifier
+                    .size(44.dp)
+                    .clip(CircleShape)
+                    .background(accent.copy(alpha = 0.14f)),
+                contentAlignment = Alignment.Center
+            ) {
+                androidx.compose.material3.Icon(
+                    Icons.Default.Terminal,
+                    null,
+                    tint = accent,
+                    modifier = Modifier.size(22.dp)
+                )
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Text(
+                    if (zh) "当前版本" else "Current version",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = Color(0xFF9AA0AF)
+                )
+                Text(
+                    versionText,
+                    style = MaterialTheme.typography.bodyLarge.copy(fontFamily = FontFamily.Monospace),
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.White
+                )
+            }
+        }
+        if (badge != null) {
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(accent.copy(alpha = 0.18f))
+                    .border(BorderStroke(1.dp, accent.copy(alpha = 0.34f)), RoundedCornerShape(999.dp))
+                    .padding(horizontal = 10.dp, vertical = 4.dp)
+            ) {
+                Text(
+                    badge,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = accent,
+                    fontWeight = FontWeight.Bold
+                )
             }
         }
     }

--- a/app/src/main/java/com/soreverse/mcp/core/GitHubUpdateManager.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/GitHubUpdateManager.kt
@@ -1,3 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2026 bilieebiliee1-design
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
 package com.soreverse.mcp.core
 
 import android.content.Context
@@ -24,6 +41,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.json.JSONArray
 import org.json.JSONObject
 
 data class GitHubRelease(
@@ -41,6 +59,9 @@ sealed interface UpdateCheckResult {
     data class Available(val release: GitHubRelease) : UpdateCheckResult
     data object Current : UpdateCheckResult
 }
+
+/** Update channel: stable official releases, or pre-release (beta) builds. */
+enum class UpdateChannel { STABLE, BETA }
 
 sealed interface UpdateDownloadEvent {
     data class Probing(val total: Int) : UpdateDownloadEvent
@@ -81,47 +102,11 @@ class GitHubUpdateManager(private val context: Context) {
     // one has fully unwound.
     private val downloadMutex = Mutex()
 
-    suspend fun check(): Result<UpdateCheckResult> = withContext(Dispatchers.IO) {
+    suspend fun check(channel: UpdateChannel = UpdateChannel.STABLE): Result<UpdateCheckResult> = withContext(Dispatchers.IO) {
         try {
-            val request = Request.Builder()
-                .url(LATEST_RELEASE_URL)
-                .header("Accept", "application/vnd.github+json")
-                .header("X-GitHub-Api-Version", "2022-11-28")
-                .header("User-Agent", "SOMCP/${BuildConfig.VERSION_NAME}")
-                .build()
-            val result = client.newCall(request).await().use { response ->
-                if (response.code == 404) return@use UpdateCheckResult.Current
-                if (!response.isSuccessful) {
-                    error(
-                        "GitHub HTTP ${response.code} ${response.message}"
-                    )
-                }
-                val root = JSONObject(response.body.string())
-                val tag = root.optString("tag_name")
-                if (!isNewer(tag, BuildConfig.VERSION_NAME)) return@use UpdateCheckResult.Current
-                val assets = root.optJSONArray("assets") ?: error("Release has no assets")
-                val apk = selectApk((0 until assets.length()).map { assets.getJSONObject(it) })
-                    ?: error("Release has no APK for ${Build.SUPPORTED_ABIS.joinToString()}")
-                val checksum = (0 until assets.length())
-                    .map { assets.getJSONObject(it) }
-                    .firstOrNull {
-                        val name = it.optString("name")
-                        name == "${apk.optString("name")}.sha256" || name == "SHA256SUMS"
-                    }
-                UpdateCheckResult.Available(
-                    GitHubRelease(
-                        tag = tag,
-                        name = root.optString("name").ifBlank { tag },
-                        notes = root.optString("body"),
-                        pageUrl = root.optString("html_url"),
-                        apkName = apk.getString("name"),
-                        apkUrl = apk.getString("browser_download_url"),
-                        apkSize = apk.optLong("size"),
-                        checksumUrl = checksum?.optString(
-                            "browser_download_url"
-                        )?.takeIf(String::isNotBlank)
-                    )
-                )
+            val result = when (channel) {
+                UpdateChannel.STABLE -> checkStable()
+                UpdateChannel.BETA -> checkBeta()
             }
             Result.success(result)
         } catch (error: CancellationException) {
@@ -129,6 +114,73 @@ class GitHubUpdateManager(private val context: Context) {
         } catch (error: Throwable) {
             Result.failure(error)
         }
+    }
+
+    private suspend fun checkStable(): UpdateCheckResult {
+        val request = Request.Builder()
+            .url(LATEST_RELEASE_URL)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "SOMCP/${BuildConfig.VERSION_NAME}")
+            .build()
+        return client.newCall(request).await().use { response ->
+            if (response.code == 404) return@use UpdateCheckResult.Current
+            if (!response.isSuccessful) {
+                error(
+                    "GitHub HTTP ${response.code} ${response.message}"
+                )
+            }
+            buildRelease(JSONObject(response.body.string()), required = true)
+        }
+    }
+
+    private suspend fun checkBeta(): UpdateCheckResult {
+        val request = Request.Builder()
+            .url("${RELEASES_URL}?per_page=30")
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "SOMCP/${BuildConfig.VERSION_NAME}")
+            .build()
+        return client.newCall(request).await().use { response ->
+            if (!response.isSuccessful) {
+                error(
+                    "GitHub HTTP ${response.code} ${response.message}"
+                )
+            }
+            val array = JSONArray(response.body.string())
+            val candidate = (0 until array.length())
+                .map { array.getJSONObject(it) }
+                .firstOrNull { it.optBoolean("prerelease") && !it.optBoolean("draft") }
+            candidate?.let { buildRelease(it, required = false) } ?: UpdateCheckResult.Current
+        }
+    }
+
+    private fun buildRelease(root: JSONObject, required: Boolean): UpdateCheckResult {
+        val tag = root.optString("tag_name")
+        if (!isNewer(tag, BuildConfig.VERSION_NAME)) return UpdateCheckResult.Current
+        val assets = root.optJSONArray("assets")
+        val apk = assets?.let { selectApk((0 until it.length()).map { index -> it.getJSONObject(index) }) }
+            ?: return if (required) error("Release has no APK for ${Build.SUPPORTED_ABIS.joinToString()}") else UpdateCheckResult.Current
+        val checksum = (0 until assets.length())
+            .map { assets.getJSONObject(it) }
+            .firstOrNull {
+                val name = it.optString("name")
+                name == "${apk.optString("name")}.sha256" || name == "SHA256SUMS"
+            }
+        return UpdateCheckResult.Available(
+            GitHubRelease(
+                tag = tag,
+                name = root.optString("name").ifBlank { tag },
+                notes = root.optString("body"),
+                pageUrl = root.optString("html_url"),
+                apkName = apk.getString("name"),
+                apkUrl = apk.getString("browser_download_url"),
+                apkSize = apk.optLong("size"),
+                checksumUrl = checksum?.optString(
+                    "browser_download_url"
+                )?.takeIf(String::isNotBlank)
+            )
+        )
     }
 
     suspend fun download(release: GitHubRelease, forcedSource: String? = null, onEvent: (UpdateDownloadEvent) -> Unit): Result<File> =
@@ -476,6 +528,7 @@ class GitHubUpdateManager(private val context: Context) {
     companion object {
         const val REPOSITORY_URL = "https://github.com/bilieebiliee1-design/SOMCP"
         private const val LATEST_RELEASE_URL = "https://api.github.com/repos/bilieebiliee1-design/SOMCP/releases/latest"
+        private const val RELEASES_URL = "https://api.github.com/repos/bilieebiliee1-design/SOMCP/releases"
         private const val CHECKSUM_MIRROR_ATTEMPTS = 4
     }
 }


### PR DESCRIPTION
## Summary

Update SOMCP's update page with the SOMCP Precision glassmorphic design and add a functional beta channel.

## Changes

- Redesigned the update interface: glowing hero state, 正式版 / 测试版 channel pill, gradient current-version power card with channel badge, richer changelog cards.
- Added `UpdateChannel` and a channel-aware `check()`: `STABLE` keeps using `/releases/latest`; `BETA` lists recent releases and selects the newest non-draft **GitHub Pre-release** that is newer than the installed build.
- The beta channel treats GitHub Pre-release as the test version; the download / multi-mirror / SHA-256 verify / install pipeline is shared.
- Start-up auto-check remains on the stable channel.
- Both modified source files carry the AGPL-3.0-or-later license header.

Commits: `15b7da5` (interface redesign), `aabdf7e` (beta channel).