### PR TITLE
fix: improve update channel visibility and persistence

### DIFF
--- a/app/src/main/java/com/soreverse/mcp/MainActivity.kt
+++ b/app/src/main/java/com/soreverse/mcp/MainActivity.kt
@@ -1,3 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2026 bilieebiliee1-design
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
 package com.soreverse.mcp
 
 import android.Manifest
@@ -317,7 +334,10 @@ private fun SoReverseApp() {
     }
     LaunchedEffect(Unit) {
         if (settings.autoCheckUpdates) {
-            updateManager.check()
+            val channel = com.soreverse.mcp.core.UpdateChannel.valueOf(
+                settings.updateChannel.uppercase()
+            )
+            updateManager.check(channel)
                 .onSuccess { result ->
                     if (result is com.soreverse.mcp.core.UpdateCheckResult.Available) {
                         availableRelease = result.release

--- a/app/src/main/java/com/soreverse/mcp/SettingsUpdatesPage.kt
+++ b/app/src/main/java/com/soreverse/mcp/SettingsUpdatesPage.kt
@@ -97,7 +97,7 @@ internal fun SettingsUpdatesPage(
     var verifyNote by remember { mutableStateOf("") }
     var status by remember { mutableStateOf("") }
     var error by remember { mutableStateOf("") }
-    var channel by remember { mutableStateOf("stable") }
+    var channel by remember { mutableStateOf(settings.updateChannel) }
 
     LaunchedEffect(release?.tag) {
         downloadedFile = release?.let(manager::cachedDownload)
@@ -275,6 +275,7 @@ internal fun SettingsUpdatesPage(
                 downloadedFile = null
                 status = ""
                 channel = newChannel
+                settings.updateChannel = newChannel
                 checkUpdates(newChannel)
             },
             zh = t.zh
@@ -297,15 +298,25 @@ internal fun SettingsUpdatesPage(
         GlassGroup {
             Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text(
-                    if (t.zh) "GitHub 正式发行版" else "Official GitHub releases",
+                    when {
+                        isBeta -> if (t.zh) "GitHub 测试发行版" else "Official GitHub pre-releases"
+                        else -> if (t.zh) "GitHub 正式发行版" else "Official GitHub releases"
+                    },
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold
                 )
                 Text(
-                    if (t.zh) {
-                        "只检查 bilieebiliee1-design/SOMCP 的正式 Release。普通构建、提交、分支和标签均不会被视为更新。"
-                    } else {
-                        "Only stable releases from bilieebiliee1-design/SOMCP are checked. Builds, commits, branches and tags do not count as updates."
+                    when {
+                        isBeta -> if (t.zh) {
+                            "只检查 bilieebiliee1-design/SOMCP 的测试 Release。普通构建、提交、分支和标签均不会被视为更新。"
+                        } else {
+                            "Only beta releases from bilieebiliee1-design/SOMCP are checked. Builds, commits, branches and tags do not count as updates."
+                        }
+                        else -> if (t.zh) {
+                            "只检查 bilieebiliee1-design/SOMCP 的正式 Release。普通构建、提交、分支和标签均不会被视为更新。"
+                        } else {
+                            "Only stable releases from bilieebiliee1-design/SOMCP are checked. Builds, commits, branches and tags do not count as updates."
+                        }
                     },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -449,11 +460,12 @@ private fun IconSmall(imageVector: ImageVector, tint: Color) {
 
 @Composable
 private fun ChannelSegmentsPill(selected: String, onSelect: (String) -> Unit, zh: Boolean) {
-    val options = listOf(
-        "stable" to (if (zh) "正式版" else "Stable"),
-        "beta" to (if (zh) "测试版" else "Beta")
-    )
     val shape = RoundedCornerShape(999.dp)
+    data class Opt(val key: String, val icon: ImageVector, val label: String)
+    val options = listOf(
+        Opt("stable", Icons.Default.Verified, if (zh) "正式版" else "Stable"),
+        Opt("beta", Icons.Default.Science, if (zh) "测试版" else "Beta")
+    )
     Row(
         Modifier
             .fillMaxWidth()
@@ -462,25 +474,47 @@ private fun ChannelSegmentsPill(selected: String, onSelect: (String) -> Unit, zh
             .border(BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.14f)), shape)
             .padding(3.dp)
     ) {
-        options.forEach { (key, label) ->
-            val active = selected == key
-            Text(
-                label,
+        options.forEach { opt ->
+            val active = selected == opt.key
+            val tint = when (opt.key) {
+                "beta" -> MaterialTheme.colorScheme.tertiary
+                else -> MaterialTheme.colorScheme.primary
+            }
+            val bgAlpha = if (active) 0.22f else 0f
+            val borderAlpha = if (active) 0.55f else 0f
+            val contentColor = if (active) {
+                tint
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.68f)
+            }
+            Row(
                 Modifier
                     .weight(1f)
                     .clip(shape)
-                    .background(if (active) MaterialTheme.colorScheme.surfaceVariant else Color.Transparent)
-                    .clickable { onSelect(key) }
-                    .padding(vertical = 9.dp),
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.bodyMedium,
-                color = if (active) {
-                    MaterialTheme.colorScheme.onSurface
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                },
-                fontWeight = if (active) FontWeight.SemiBold else FontWeight.Medium
-            )
+                    .background(tint.copy(alpha = bgAlpha))
+                    .border(
+                        BorderStroke(1.dp, tint.copy(alpha = borderAlpha)),
+                        shape
+                    )
+                    .clickable { if (!active) onSelect(opt.key) }
+                    .padding(vertical = 10.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                androidx.compose.material3.Icon(
+                    opt.icon,
+                    null,
+                    tint = contentColor,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(Modifier.size(5.dp))
+                Text(
+                    opt.label,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = contentColor,
+                    fontWeight = if (active) FontWeight.Bold else FontWeight.Medium
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/SettingsStore.kt
@@ -1,3 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2026 bilieebiliee1-design
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
 package com.soreverse.mcp.core
 
 import android.content.Context
@@ -453,6 +470,13 @@ class SettingsStore(context: Context) {
     var autoCheckUpdates: Boolean
         get() = prefs.getBoolean("autoCheckUpdates", true)
         set(value) = prefs.edit().putBoolean("autoCheckUpdates", value).apply()
+
+    var updateChannel: String
+        get() = prefs.getString("updateChannel", "stable") ?: "stable"
+        set(value) = prefs.edit().putString(
+            "updateChannel",
+            if (value in setOf("stable", "beta")) value else "stable"
+        ).apply()
 
     // ---- Cloudflare Tunnel ----
     var tunnelMode: String


### PR DESCRIPTION
## 问题

1. Channel 切换 Tab（正式版/测试版）的选中态视觉差异极弱——激活段只有 `surfaceVariant` 背景色，深色主题下几乎无法分辨当前选的是哪个
2. GlassGroup 的标题和描述文案写死了「正式 Release」，切换到测试版也不变化
3. 上次选择的 channel 不会持久化，重启后回到默认的 stable

## 变更

| 文件 | 改动 |
|---|---|
| `SettingsUpdatesPage.kt` | 重写 `ChannelSegmentsPill`：每段加独立图标（Verified = 正式版，Science = 测试版），激活态使用专属强调色（primary / tertiary）带彩色背景+边框+加粗文字，未激活态整体降饱和 |
| `SettingsUpdatesPage.kt` | GlassGroup 标题/描述根据 `isBeta` 动态切换：正式版显示「正式 Release」，测试版显示「测试 Release」 |
| `SettingsUpdatesPage.kt` | channel 初始值改为从 `SettingsStore` 读取，切换 Pill 时同步保存 |
| `SettingsStore.kt` | 新增 `updateChannel` 持久化字段（值为 `stable` / `beta`，默认 `stable`） |
| `MainActivity.kt` | 启动时自动检查不再固定用 STABLE，读取保存的 channel |
| `MainActivity.kt` / `SettingsStore.kt` | 补充缺失的 AGPL-3.0 许可证头 |

## 测试建议

- 打开「版本更新」页面，Tab 中哪个有彩色图标+彩色边框+加粗文字即为当前选中
- 切到测试版后，GlassGroup 标题应显示「GitHub 测试发行版」，描述应写「测试 Release」
- 关闭应用重开，channel 选项卡应恢复上次选择的位置