### PR TITLE
fix(saf): stop gating folder picker launch on resolveActivity

### DIFF
--- a/app/src/main/java/com/soreverse/mcp/ExternalLinks.kt
+++ b/app/src/main/java/com/soreverse/mcp/ExternalLinks.kt
@@ -31,15 +31,23 @@ import com.soreverse.mcp.core.AppLog
  * Safely launches the SAF directory-tree picker ([Intent.ACTION_OPEN_DOCUMENT_TREE]).
  *
  * Some OEM builds (e.g. EMUI/HarmonyOS on Huawei) ship without any app that can
- * handle this action. Pointing a plain `ActivityResultLauncher` at it would throw
- * [ActivityNotFoundException] (and crash) when launched. This helper first checks
- * [resolveActivity]; if no handler exists it surfaces a Toast instead of crashing,
- * and still guards the launch against a race where the handler disappears.
+ * handle this action, and pointing a plain `ActivityResultLauncher` at it would then
+ * throw [ActivityNotFoundException]. This helper guards the launch in a try/catch and
+ * surfaces a Toast instead of crashing.
+ *
+ * IMPORTANT: the launch is NOT pre-gated on `intent.resolveActivity()`. On several OEM
+ * ROMs (OnePlus/ColorOS, some MIUI builds) the resolver reports no handler for
+ * `ACTION_OPEN_DOCUMENT_TREE` through `resolveActivity()` even though a working SAF
+ * document provider is installed and `startActivityForResult` succeeds. Gating the
+ * launch on that (unreliable) check produced the false "无 SAF 文件提供方 / no folder
+ * picker" error on otherwise healthy devices. We launch directly and only surface the
+ * helper message when the system genuinely throws [ActivityNotFoundException].
  */
 internal fun launchSafTreePicker(context: Context, zh: Boolean, launcher: ActivityResultLauncher<Uri?>) {
-    val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
-    if (intent.resolveActivity(context.packageManager) == null) {
-        AppLog.w("No activity can handle ACTION_OPEN_DOCUMENT_TREE; SAF folder picker unavailable.")
+    try {
+        launcher.launch(null)
+    } catch (_: ActivityNotFoundException) {
+        AppLog.w("ACTION_OPEN_DOCUMENT_TREE not handled; SAF folder picker unavailable.")
         Toast.makeText(
             context,
             if (zh) {
@@ -47,17 +55,6 @@ internal fun launchSafTreePicker(context: Context, zh: Boolean, launcher: Activi
             } else {
                 "No folder picker available on this device (no SAF document provider). Install or enable a file manager and retry."
             },
-            Toast.LENGTH_LONG
-        ).show()
-        return
-    }
-    try {
-        launcher.launch(null)
-    } catch (_: ActivityNotFoundException) {
-        AppLog.w("ACTION_OPEN_DOCUMENT_TREE handler vanished between resolveActivity and launch.")
-        Toast.makeText(
-            context,
-            if (zh) "无法打开文件夹选择器，请稍后重试。" else "Cannot open folder picker. Please retry.",
             Toast.LENGTH_LONG
         ).show()
     }


### PR DESCRIPTION
Closes #71

## 🔧 修复 Issue #71 — 新版（1.0.20+）在部分设备上无法选择工作目录（无 SAF 文件提供方）

---

### 📎 修改概要

| 文件 | 变更 |
|---|---|
| `app/src/main/java/com/soreverse/mcp/ExternalLinks.kt` | `launchSafTreePicker` 去掉 `resolveActivity` 前置门控 |

### 🔍 根因分析

`launchSafTreePicker` 在启动选择器前先调用 `intent.resolveActivity(context.packageManager)`，若返回 `null` 就直接弹出“当前设备没有可用的文件夹选择器（无 SAF 文件提供方）”并 `return`。

在部分 OEM ROM（一加/ColorOS、部分 MIUI）上，`resolveActivity` 对 `ACTION_OPEN_DOCUMENT_TREE` 会**错误地返回 null**——即使设备实际安装并启用了可用的 SAF 文档提供方，`startActivityForResult` 也能正常拉起选择器。前置门控导致这些正常设备被误判为“无 SAF 提供方”，正是 Issue #71 中一加 ACEPro 上出现的现象。

### ✅ 修复方案

改为不依赖 `resolveActivity` 做前置判断：直接调用 `launcher.launch(null)`，只有当系统真正抛出 `ActivityNotFoundException` 时才显示引导提示。原有的 try/catch 已保证不会崩溃。

- 有 SAF 提供方的设备：正常拉起文件夹选择器（修复误报）；
- 确实没有提供方的设备：仍会收到原提示，行为不变。

### 📝 备注

Issue #71 中的另一问题（1.0.19 缺少 unicorn 库）为 #68 的重复提交，已由 PR #69 修复，本次不重复处理。