### PR TITLE
fix: 备份页加密开关与包含密钥联动修复

### DIFF
--- a/app/src/main/java/com/soreverse/mcp/SettingsBackupRestorePage.kt
+++ b/app/src/main/java/com/soreverse/mcp/SettingsBackupRestorePage.kt
@@ -388,6 +388,7 @@ internal fun SettingsBackupRestorePage(t: UiText, settings: SettingsStore) {
             confirmButton = {
                 Button(onClick = {
                     showEncryptWarning = false
+                    encryptEnabled = true
                 }) { Text(if (t.zh) "知道了" else "OK") }
             }
         )
@@ -409,6 +410,11 @@ internal fun SettingsBackupRestorePage(t: UiText, settings: SettingsStore) {
                 checked = includeSecrets
             ) { enabled ->
                 includeSecrets = enabled
+                if (enabled && !encryptEnabled) {
+                    // 包含密钥时强制启用密码加密
+                    encryptEnabled = true
+                    showEncryptWarning = true
+                }
             }
             GroupDivider()
             BackupToggleRow(
@@ -432,6 +438,8 @@ internal fun SettingsBackupRestorePage(t: UiText, settings: SettingsStore) {
                         label = { Text(t.backupEncryptPassword) },
                         placeholder = { Text(t.backupPasswordPlaceholder) },
                         singleLine = true,
+                        visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                         shape = RoundedCornerShape(12.dp),
                         colors = OutlinedTextFieldDefaults.colors(
                             focusedBorderColor = MaterialTheme.colorScheme.primary,


### PR DESCRIPTION
- 修复「使用密码加密」开关打开后加密密码输入框不显示的问题（警告弹窗确认后未置 encryptEnabled=true）
- 修复开启「包含密钥」时未强制启用密码加密的问题
- 加密密码输入框增加掩码显示（PasswordVisualTransformation）