### PR TITLE
fix: 包含密钥时锁定密码加密开关，禁止关闭

### DIFF
--- a/app/src/main/java/com/soreverse/mcp/SettingsBackupRestorePage.kt
+++ b/app/src/main/java/com/soreverse/mcp/SettingsBackupRestorePage.kt
@@ -564,7 +564,7 @@ internal fun SettingsBackupRestorePage(t: UiText, settings: SettingsStore) {
 }
 
 @Composable
-private fun BackupToggleRow(text: String, subtitle: String, checked: Boolean, onChange: (Boolean) -> Unit, enabled: Boolean = true) {
+private fun BackupToggleRow(text: String, subtitle: String, checked: Boolean, enabled: Boolean = true, onChange: (Boolean) -> Unit) {
     val metrics = LocalUiMetrics.current
     Row(
         Modifier

--- a/app/src/main/java/com/soreverse/mcp/SettingsBackupRestorePage.kt
+++ b/app/src/main/java/com/soreverse/mcp/SettingsBackupRestorePage.kt
@@ -564,13 +564,7 @@ internal fun SettingsBackupRestorePage(t: UiText, settings: SettingsStore) {
 }
 
 @Composable
-private fun BackupToggleRow(
-    text: String,
-    subtitle: String,
-    checked: Boolean,
-    onChange: (Boolean) -> Unit,
-    enabled: Boolean = true
-) {
+private fun BackupToggleRow(text: String, subtitle: String, checked: Boolean, onChange: (Boolean) -> Unit, enabled: Boolean = true) {
     val metrics = LocalUiMetrics.current
     Row(
         Modifier
@@ -607,12 +601,7 @@ private fun BackupToggleRow(
  * where the thumb incorrectly stayed pinned to the left.
  */
 @Composable
-private fun BackupSwitch(
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true
-) {
+private fun BackupSwitch(checked: Boolean, onCheckedChange: (Boolean) -> Unit, modifier: Modifier = Modifier, enabled: Boolean = true) {
     val trackWidth = 48.dp
     val trackHeight = 28.dp
     val thumbSize = 24.dp

--- a/app/src/main/java/com/soreverse/mcp/SettingsBackupRestorePage.kt
+++ b/app/src/main/java/com/soreverse/mcp/SettingsBackupRestorePage.kt
@@ -63,6 +63,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -420,11 +421,13 @@ internal fun SettingsBackupRestorePage(t: UiText, settings: SettingsStore) {
             BackupToggleRow(
                 text = t.backupEncryptToggle,
                 subtitle = t.backupEncryptToggleSubtitle,
-                checked = encryptEnabled
+                checked = encryptEnabled,
+                // 包含密钥时锁定开关，强制保持密码加密开启
+                enabled = !includeSecrets
             ) { enabled ->
                 if (enabled) {
                     showEncryptWarning = true
-                } else {
+                } else if (!includeSecrets) {
                     encryptEnabled = false
                     encryptPassword = ""
                 }
@@ -561,7 +564,13 @@ internal fun SettingsBackupRestorePage(t: UiText, settings: SettingsStore) {
 }
 
 @Composable
-private fun BackupToggleRow(text: String, subtitle: String, checked: Boolean, onChange: (Boolean) -> Unit) {
+private fun BackupToggleRow(
+    text: String,
+    subtitle: String,
+    checked: Boolean,
+    onChange: (Boolean) -> Unit,
+    enabled: Boolean = true
+) {
     val metrics = LocalUiMetrics.current
     Row(
         Modifier
@@ -585,7 +594,8 @@ private fun BackupToggleRow(text: String, subtitle: String, checked: Boolean, on
         }
         BackupSwitch(
             checked = checked,
-            onCheckedChange = onChange
+            onCheckedChange = onChange,
+            enabled = enabled
         )
     }
 }
@@ -597,7 +607,12 @@ private fun BackupToggleRow(text: String, subtitle: String, checked: Boolean, on
  * where the thumb incorrectly stayed pinned to the left.
  */
 @Composable
-private fun BackupSwitch(checked: Boolean, onCheckedChange: (Boolean) -> Unit, modifier: Modifier = Modifier) {
+private fun BackupSwitch(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
     val trackWidth = 48.dp
     val trackHeight = 28.dp
     val thumbSize = 24.dp
@@ -618,8 +633,10 @@ private fun BackupSwitch(checked: Boolean, onCheckedChange: (Boolean) -> Unit, m
                     MaterialTheme.colorScheme.outline.copy(alpha = 0.35f)
                 }
             )
+            .alpha(if (enabled) 1f else 0.4f)
             .toggleable(
                 value = checked,
+                enabled = enabled,
                 role = Role.Switch,
                 onValueChange = onCheckedChange
             ),


### PR DESCRIPTION
## 问题

备份与恢复界面中，开启“包含密钥”后虽然会强制打开“使用密码加密”，但“使用密码加密”开关仍可被手动关闭，导致包含密钥的备份可能以明文写入。

## 修复

- 开启“包含密钥”后，“使用密码加密”开关锁定为开启状态（`enabled = !includeSecrets`），无法手动关闭。
- 开关禁用时以降低透明度方式呈现，并增加防御性校验，确保包含密钥时无法关闭加密。
- 关闭“包含密钥”后开关恢复可操作，用户仍可自行关闭密码加密。

## 变更文件

- `app/src/main/java/com/soreverse/mcp/SettingsBackupRestorePage.kt`
