### PR TITLE
fix: 修复备份页开关颜色与CF隧道启动权限问题

### DIFF
--- a/app/src/main/java/com/soreverse/mcp/SettingsBackupRestorePage.kt
+++ b/app/src/main/java/com/soreverse/mcp/SettingsBackupRestorePage.kt
@@ -611,18 +611,16 @@ private fun BackupSwitch(checked: Boolean, onCheckedChange: (Boolean) -> Unit, m
         animationSpec = tween(durationMillis = 200, easing = FastOutSlowInEasing),
         label = "backupSwitchThumb"
     )
+    val trackColor = when {
+        checked && enabled -> MaterialTheme.colorScheme.primary
+        checked && !enabled -> MaterialTheme.colorScheme.primary.copy(alpha = 0.65f)
+        else -> MaterialTheme.colorScheme.outline.copy(alpha = 0.45f)
+    }
     Box(
         modifier = modifier
             .size(width = trackWidth, height = trackHeight)
             .clip(RoundedCornerShape(trackHeight / 2))
-            .background(
-                if (checked) {
-                    MaterialTheme.colorScheme.primaryContainer
-                } else {
-                    MaterialTheme.colorScheme.outline.copy(alpha = 0.35f)
-                }
-            )
-            .alpha(if (enabled) 1f else 0.4f)
+            .background(trackColor)
             .toggleable(
                 value = checked,
                 enabled = enabled,
@@ -649,7 +647,7 @@ private fun BackupActionCard(label: String, icon: ImageVector, onClick: () -> Un
             .clip(shape)
             .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.92f))
             .border(
-                BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)),
+                BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.28f)),
                 shape
             )
             .clickable(onClick = onClick)
@@ -661,7 +659,7 @@ private fun BackupActionCard(label: String, icon: ImageVector, onClick: () -> Un
             Modifier
                 .size(44.dp)
                 .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)),
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.22f)),
             contentAlignment = Alignment.Center
         ) {
             Icon(

--- a/app/src/main/java/com/soreverse/mcp/core/CloudflareTunnelManager.kt
+++ b/app/src/main/java/com/soreverse/mcp/core/CloudflareTunnelManager.kt
@@ -71,6 +71,21 @@ class CloudflareTunnelManager(private val context: Context, private val settings
             }
             return BinaryState.NOT_FOUND
         }
+
+        /**
+         * Best-effort chmod +x on Android. [File.setExecutable] often silently
+         * fails under SELinux; calling the chmod binary directly works even on
+         * non-rooted devices when operating on the app's private directory.
+         */
+        fun chmodExecutable(file: File) {
+            runCatching {
+                // Try File API first (works on some older devices / emulators)
+                if (file.setExecutable(true, false)) return
+                // Fallback: exec chmod through Runtime (reliable on Android)
+                val proc = Runtime.getRuntime().exec(arrayOf("chmod", "755", file.absolutePath))
+                proc.waitFor()
+            }
+        }
     }
 
     data class TunnelStatus(
@@ -236,10 +251,11 @@ class CloudflareTunnelManager(private val context: Context, private val settings
             val target = File(dir, CLOUDFLARED_FILE)
             if (target.exists()) target.delete()
             tmp.renameTo(target)
-            // Make executable
-            target.setExecutable(true, false)
+            // Make executable — File.setExecutable may silently fail under
+            // SELinux; chmod via Runtime.exec reliably sets the bits on Android.
+            chmodExecutable(target)
             _binaryState.set(BinaryState.READY)
-            AppLog.i("cloudflared binary downloaded to ${target.absolutePath}")
+            AppLog.i("cloudflared binary downloaded to ${target.absolutePath}, executable=${target.canExecute()}")
         } catch (e: Exception) {
             _binaryState.set(BinaryState.NOT_FOUND)
             throw e
@@ -548,6 +564,12 @@ class CloudflareTunnelManager(private val context: Context, private val settings
             if (index > 0 && cmd[index - 1] == "--token") "<redacted>" else value
         }
         AppLog.i("cloudflare tunnel command: ${safeCommand.joinToString(" ")}")
+        // Ensure the binary is executable right before launch — the file may
+        // have been restored from a backup or adb push without execute bits.
+        chmodExecutable(bin)
+        if (!bin.canExecute()) {
+            AppLog.w("cloudflared binary is still not executable after chmod attempt")
+        }
         val pb = ProcessBuilder(cmd).directory(context.cacheDir).redirectErrorStream(true)
         pb.environment()["NO_AUTOUPDATE"] = "true"
         // The bare pb.start() call below can throw IOException when the device
@@ -561,7 +583,15 @@ class CloudflareTunnelManager(private val context: Context, private val settings
             pb.start()
         } catch (e: Exception) {
             AppLog.w("cloudflared process spawn failed: ${e.message}")
-            fail(mode, targetPort, "spawn failed: ${e.message ?: e.javaClass.simpleName}")
+            val msg = e.message ?: e.javaClass.simpleName
+            val friendly = if (msg.contains("Permission denied", ignoreCase = true) ||
+                msg.contains("error=13")
+            ) {
+                "无法执行 cloudflared 二进制文件（权限问题）。请尝试重新下载：$msg"
+            } else {
+                "spawn failed: $msg"
+            }
+            fail(mode, targetPort, friendly)
             return
         }
         process = p


### PR DESCRIPTION
## 变更内容

修复三个问题：

1. **备份与恢复页面按钮颜色不明显**
   - 开关选中轨道改用主色（`primary`），替代原先深色模式下几乎不可见的 `primaryContainer`（仅 18% 透明度）
   - 禁用锁定的开关不再整体降透明度，改为轨道使用 65% 主色，明确显示"锁定开启"状态
   - 导出/导入按钮图标圆形背景加深（10% → 22% 主色），边框更清晰

2. **包含密钥开关联动颜色丢失**
   - 关闭"包含密钥"后，被锁定的"使用密码加密"开关此前因整体 alpha 0.4 褪色而颜色消失，已修复为清晰显示主色锁定态

3. **CF 隧道无法启动（Permission denied）**
   - `File.setExecutable` 在 SELinux 下常静默失败，新增 `chmodExecutable()` 使用 `Runtime.exec("chmod")` 兜底
   - 下载完成后与每次启动前都确保二进制可执行
   - 权限失败时给出友好的中文错误提示

## 测试说明

- 改动仅涉及 Compose UI 颜色与 cloudflared 进程启动逻辑，无新增依赖