### PR TITLE
ci: 只保留 tag 触发构建 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
将 release.yml 触发条件调整为仅保留 tag 推送（push tags v*），移除 workflow_dispatch 手动触发。